### PR TITLE
Fix recovery limits being applied after initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.9.1-rc1 - 2026-09-12
+
+- Fix hidden-app recovery patch timing: preload the recovery module at the
+  SceShell recovery-load call and patch it before PAF Plugin initialization.
+- Reuse the native PAF module cache and balance the extra module reference after
+  load completion, including failed and duplicate loads. Remove the later
+  recovery-ready entry hook and call its original void callback directly.
+- Keep interception process-local. No shared PAF/SceLibKernel code hooks and no
+  private controller recovery are introduced. Capacity/cache behavior is unchanged.
+- Add diagnostic initializer, preload, completion and cleanup events. Publish
+  logging-enabled normal and no-cache comparisons for reporters.
+
+Offline ARM tests reproduce the correct restoration decision for both reporters
+(500 visible plus 49/73 hidden). They do not prove that issue #8’s boot freeze is
+resolved or that the real database/UI recovered; hardware confirmation is pending.
+
 ## 1.9.0 - 2026-09-12
 
 - Replace shared PAF cache/consumer hooks with private virtual tables on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 	endif()
 endif()
 
-project(livearea_nolimits VERSION 1.9.0 LANGUAGES C ASM)
+project(livearea_nolimits VERSION 1.9.1 LANGUAGES C ASM)
 include("${VITASDK}/share/vita.cmake" REQUIRED)
 
 option(LIVEAREA_ICON_CACHE_TRIAL
@@ -32,13 +32,13 @@ add_executable(livearea_nolimits
 	src/main.c
 	src/recovery.c
 	src/patch_bytes.S
+	src/shell_detour.c
 )
 
 if(LIVEAREA_ICON_CACHE_TRIAL)
 	target_sources(livearea_nolimits PRIVATE src/instance_cache.c
-		src/instance_cache_entry.S src/shell_detour.c)
+		src/instance_cache_entry.S)
 	target_compile_definitions(livearea_nolimits PRIVATE LIVEAREA_ICON_CACHE_TRIAL=1)
-	target_link_libraries(livearea_nolimits SceKernelThreadMgr_stub)
 endif()
 
 if(LIVEAREA_DEBUG_LOGGING)
@@ -75,6 +75,7 @@ target_include_directories(livearea_nolimits PRIVATE
 target_link_libraries(livearea_nolimits
 	taihen_stub
 	SceKernelModulemgr_stub
+	SceKernelThreadMgr_stub
 	# System imports must precede newlib's application-runtime definitions.
 	SceLibKernel_stub
 	c

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ instead of hooking shared PAF executable code. It retains single-victim LRU
 texture eviction and artwork reload, uses one SUPRX, and disables runtime logging.
 Replace your existing SUPRX and fully reboot to upgrade.
 
+The `fix/recovery-init-order` branch contains the **v1.9.1-rc1 recovery candidate**.
+It moves recovery patching before Plugin initialization; matching logging-enabled
+builds are for the reporters in #8/#10. The regular v1.9.0 release remains unchanged.
+See [recovery timing and validation](docs/recovery.md).
+
 The 50-page, 500-top-level and 4,000-counted-icon limits are unchanged. Hidden-app
 recovery is unchanged too: fresh hidden-app restoration in
 [#10](https://github.com/devnoname120/livearea_nolimits/issues/10) and the reported

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -7,23 +7,25 @@ icon-cache correction. It extends the existing `SceDbRecovery` algorithm; it doe
 not rebuild `app.db`, reinstall applications, suppress the warning, or introduce
 a second database implementation. Runtime logging remains disabled by default.
 
-Version 1.8.0-rc1 replaces the shared-library lifecycle hooks with a
-SceShell-local recovery-ready callback and a temporary redirect of the loaded
-recovery module's stop entry. It retains the seven capacity patches. The
-prerelease has diagnostic logging enabled; ordinary source builds still default
-to logging disabled. See [reporter diagnostics](diagnostics.md).
+The v1.9.1-rc1 candidate fixes the initialization-order regression in v1.8.0
+and v1.9.0. It preloads `SceDbRecovery` at SceShell's specific recovery-load call,
+installs the seven capacity patches after module start/relocation but before PAF
+constructs and initializes the Plugin, and then resumes normal asynchronous loading.
+The later SceShell ready callback is called directly, with its correct void ABI.
+Its entry is no longer hooked and no substitute continuation is involved.
 
-The current callback implementation is a candidate for reporter testing.
-Offline checks cover host lifecycle behavior with firmware bytes, native ARM
-capacity/planning instructions, and hook relocation. The earlier retail 3.65
-500-visible/73-hidden hardware result belongs to v1.7.0's previous interception
-path and is not hardware validation of v1.8.0-rc1. The candidate still needs
-confirmation of real hidden-app recovery, application launch, and sleep/wake.
+This candidate is for reporter validation. Offline tests reproduce both supplied
+500-visible/49-hidden and 500-visible/73-hidden recovery decisions and validate
+module-reference/patch cleanup. They do not execute the full database/UI/scheduler
+or establish that the reported pre-LiveArea freeze in #8 is fixed. No physical
+Vita testing was performed for this candidate. The existing v1.9.0 stable release
+and its per-instance icon-cache implementation are otherwise unchanged.
 
-Version 1.7.0 removed the unsafe allocator-entry hook but retained lifecycle
-hooks in shared `SceLibKernel`. Issue #6's VitaShell dumps subsequently identified
-branches into SceShell-only plugin code from another process. The preceding
-allocator problem and its historical tests are documented below.
+The earlier shared-library hooks in v1.7.0 applied limits early enough but exposed
+other processes to SceShell-only callbacks. v1.8.0 removed those hooks, but its
+replacement ran after the initializer had stored its recovery decision. Late
+patching cannot update that decision. The historical allocator-hook problem is
+documented below; neither form of shared hook is restored here.
 
 ## Why installation order matters
 
@@ -133,41 +135,64 @@ assets.
 
 ## Module lifecycle
 
-No module-manager import in `SceLibKernel`, `ScePaf`, or another shared library
-is hooked. The plugin validates SceShell's identity, text size, and the 12-byte
-entry sequence at segment-0 offset `0x1BFE`, then hooks that shell-local callback.
-Each of the three supported shell profiles has its own expected bytes.
+The only permanent recovery interception is a four-byte `BL` replacement at
+SceShell text offset `0xC1E`. Startup validates the complete surrounding 16-byte
+call sequence, including the relocated local finish-callback address and original
+call instruction. Other PAF plugin-load calls are not intercepted. The wrapper
+also checks the exact plugin name, module filename, interface version, option and
+finish callback before taking ownership.
 
-In the inspected retail 3.65 image, SceDbRecovery's module_start runs static
-constructors and registers PAF interface 1. SceShell's callback obtains that
-interface and invokes its initialization entry at interface offset +4. The new
-hook installs the recovery capacity patches before continuing to that native
-callback, after the recovery module has started and relocation has completed.
-This timing avoids the old allocator relocation collision. Actual affected-device
-recovery through this callback remains a reporter acceptance test.
+| Shell | Original LoadAsync import offset | Original BLX bytes |
+| --- | --- | --- |
+| Retail 3.60 | `0x45CA50` | `5B F0 18 E7` |
+| Retail 3.65 | `0x45CE98` | `5C F0 3C E1` |
+| PTEL 3.60 | `0x452C08` | `51 F0 F4 E7` |
 
-The hook validates the loaded recovery module identity, both segment sizes, all
-seven original patch instructions, and the complete ten-byte module_stop entry
-at segment-0 offset `0x1E`. Before installing capacity patches, it redirects that
-stop entry to the plugin. The redirect is an unaligned Thumb literal branch;
-o substitute trampoline or pre-start allocator hook is used there.
+The original SceShell import stub is left intact and called normally. PAF Module
+acquire/release/interface helpers are selected by the matched PAF NID and checked
+native instruction sequences. The wrapper mirrors PAF's effective module option,
+including its common-dialog mode bit. It declines an untracked preexisting
+recovery module because initialization timing cannot be established for that state.
 
-When native module stop is requested, the redirect restores the capacity patches
-and the original stop entry while the module is still mapped, then calls the
-original stop with its arguments. The inspected native stop finalizes the module
-runtime and returns success. If cleanup fails, stop is cancelled and the remaining
-patch handles are retained for retry. The plugin refuses its own unload while
-recovery modifications or an active ready callback still depend on its code.
+The preload starts the module and registers its interface; it does not run the
+Plugin initializer. PAF's filename cache lets the subsequent native Plugin load
+reuse that ModuleImpl, taking its own reference. The preload stays alive through
+the original finish callback, then its extra reference is released. Failed
+preloads are released before native LoadAsync retries, so an unsuccessful cached
+ModuleImpl cannot be kept alive by the wrapper. Duplicate pending loads share the
+retained reference until their callbacks complete. Preparing/releasing/blocked
+states reject unsafe reentry. An unexpected owner mismatch retains the preload
+rather than stopping an unverified owner.
 
-Identity or byte mismatches leave recovery unmodified. Partial installation rolls
-back; if rollback fails, the native ready callback is blocked rather than running
-with a partial patch set. None of these optional recovery failures removes the
-already-installed shell capacity patches or the independent icon-cache correction.
+Before modifying the recovery module, validate its UID/NID, both segments, all
+seven original patch sites, module-stop body and relocated five-entry module
+interface. The interface returned by PAF must match that module's data segment.
+This is the Module interface; the Plugin has a separate interface table at object
+`+0x58`, which the native initializer populates for the later SceShell callback.
+The high shared-address window is rejected for recovery code/data. A private
+module-stop redirect restores the temporary patches while the module is
+still mapped, then calls its original stop. No lifecycle mutex is held across
+native module construction/destruction, load requests or client callbacks.
 
-Diagnostic logs distinguish callback installation, callback invocation, unpatched
-fallback, each injection, successful patching, native entry/return, rollback, and
-stop cleanup. `ready-hook` alone does not prove that recovery ran, and a native
-callback return does not prove that all hidden apps were restored.
+Diagnostic builds also redirect the initializer pointer in the private module's
+interface table at data offset `+4`. The observer logs entry/return and the stored
+action flags, then delegates to the original initializer at text `+0x9A`. This
+uses the native callback table, with no executable-entry trampoline. The pointer
+is restored with the other temporary modifications before module stop. It is
+compiled out when logging is disabled.
+
+Partial installation rolls back. If rollback fails, the preload and callback code
+remain retained and Plugin initialization is blocked; a partly patched recovery
+module must not execute. A live call site or retained module prevents hot unload.
+Switch builds by full reboot. These optional recovery errors never remove the
+baseline shell capacity patches or the independent icon-cache correction.
+
+Logs distinguish `preload-enter/return`, successful preparation before the
+initializer, `init-enter/return`, `load-finished`, `finish-native-enter/return`,
+preload release and module-stop cleanup. The initializer's restoration flag is
+`0x80000` for the validated normal-boot test cases with hidden apps and remaining
+capacity. Flags and successful callbacks are not a restored-app count; reporter
+confirmation of the actual resulting layout remains necessary.
 
 ## Repeating offline verification
 
@@ -191,9 +216,9 @@ python3 tests/run.py \
 ```
 
 The substitute checkout must be at the revision documented in the icon-cache
-notes. Its relocator tests cover the remaining shell and PAF function hooks; the
-recovery callback and its stop redirect are checked separately against the
-selected firmware bytes and the pinned hook engine.
+notes. Its relocator tests are historical cache-policy comparisons. Current cache and
+recovery code do not install shared PAF or SceLibKernel entry hooks. Current recovery
+call dispatch and its stop redirect are checked with compiled ARM code.
 
 Host tests use placeholder replacement bytes, as the existing shell tests do.
 The separate optional instruction test requires Unicorn 2.x and an unstripped
@@ -232,7 +257,7 @@ shell and recovery verification against the final assembled plugin.
 hidden applications. The database update completed, all 73 applications appeared
 across 15 pages, and the recovery module stopped and rolled back its temporary
 patches cleanly. Equivalent affected-library recovery remains untested on retail
-3.60 and PTEL 3.60 hardware. The v1.8.0-rc1 callback implementation requires new
+3.60 and PTEL 3.60 hardware. The v1.9.1-rc1 preload implementation requires new
 reporter confirmation on affected devices; these older results do not carry over.
 
 Keep backups of the active plugin, configuration, and a stock-compatible layout
@@ -245,3 +270,21 @@ plugin, or use Safe Mode database rebuild as the destructive fallback.
 At the real configured counted-icon or top-level capacity, applications can still
 remain hidden. A persistent warning at those boundaries is not the old 500-limit
 bug, and this extension intentionally does not hide it.
+
+## Recovery candidate instruction test
+
+`tests/test_recovery_preload_arm.py PLUGIN_ELF EVIDENCE_ROOT` executes the compiled
+call-site wrapper, native PAF Module acquire/reuse/release code and interface-copy
+sequence, initializer observer and original SceShell ready callback. The native
+recovery initializer and completion-registration routine run in a separate Unicorn
+context using the exact capacity bytes installed by the compiled wrapper. This
+avoids overlapping link-address spaces while preserving the tested patch timing.
+OS, strings/maps, asynchronous scheduling, environment lookup and UI services are
+modeled. Passing this test is not a full-system boot test.
+
+The evidence root is the main checkout's local `build/` directory containing the
+private firmware inputs used by the existing profile tests. `--database` can be
+repeated to derive visible/hidden counts from supplied read-only database copies.
+Both reporter count cases are included by default. Failure cases cover start or
+interface failure, individual patch/observer failures, incomplete rollback and
+failed Plugin load, as well as successful cleanup without retained ModuleImpls.

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -1,4 +1,7 @@
 #include <psp2/kernel/modulemgr.h>
+#include <psp2/kernel/threadmgr/lw_mutex.h>
+#include <stddef.h>
+#include <stdatomic.h>
 #include <psp2/types.h>
 #include <stdint.h>
 #include <string.h>
@@ -6,6 +9,7 @@
 
 #include "debug_log.h"
 #include "recovery.h"
+#include "shell_detour.h"
 
 #define RECOVERY_TEXT_SIZE 0x3E9E8U
 #define RECOVERY_DATA_SIZE 0x3094U
@@ -13,6 +17,9 @@
 #define RECOVERY_ERROR (-1)
 #define ARRAY_COUNT(a) (sizeof(a) / sizeof((a)[0]))
 #define SHELL_RECOVERY_READY_OFFSET 0x1BFEU
+#define SHELL_RECOVERY_LOAD_CALL_OFFSET 0xC1EU
+#define RECOVERY_INITIALIZER_OFFSET 0x9AU
+#define RECOVERY_ACTION_FLAGS_OFFSET 0x1100U
 
 extern const uint8_t patch_cmp_r0_icon_limit[4];
 extern const uint8_t patch_rsbs_r1_r0_icon_limit[4];
@@ -27,11 +34,35 @@ typedef struct {
 } RecoveryPatch;
 
 typedef struct {
-	uint32_t shell_nid;
-	uint32_t recovery_nid;
-	uint32_t shell_text_size;
-	uint8_t ready_prefix[12];
+	uint32_t shell_nid, recovery_nid, shell_text_size, paf_nid, load_import;
+	uint8_t load_call[4];
 } RecoveryProfile;
+
+/* PAF's native Module wrapper is a single owning ModuleImpl pointer. */
+typedef struct {
+	uint32_t name[3];
+	SceUID handle;
+	uint32_t interfaces[3];
+	int32_t references, option, result;
+} PafModuleImpl;
+typedef struct { PafModuleImpl *impl; } PafModule;
+typedef struct { const char *data; uint32_t length, capacity; } PafString;
+typedef struct {
+	PafString name, caller;
+	uintptr_t functions[5];
+	uint8_t middle[60];
+	PafString module_file;
+	int32_t module_interface_version, module_option;
+} PafLoadParam;
+typedef void (*LoadFinish)(void *plugin);
+typedef void (*LoadAsync)(const PafLoadParam *, LoadFinish, int);
+#if UINTPTR_MAX == UINT32_MAX
+_Static_assert(sizeof(PafModule)==4 && sizeof(PafString)==12, "PAF wrapper ABI");
+_Static_assert(offsetof(PafModuleImpl,handle)==12 && offsetof(PafModuleImpl,references)==28 &&
+	offsetof(PafModuleImpl,result)==36, "PAF ModuleImpl ABI");
+_Static_assert(offsetof(PafLoadParam,module_file)==104 &&
+	offsetof(PafLoadParam,module_option)==120, "PAF InitParam ABI");
+#endif
 
 typedef int (*RecoveryStop)(SceSize args, const void *argp);
 
@@ -46,21 +77,9 @@ static const RecoveryPatch recovery_patches[] = {
 };
 
 static const RecoveryProfile recovery_profiles[] = {
-	{
-		0x0552F692U, 0xC1F30F67U, 0x541B74U,
-		{0x10, 0xB5, 0x01, 0x21, 0x5A, 0xF0, 0x1E, 0xE6,
-		 0x04, 0x1C, 0x0D, 0xD0},
-	},
-	{
-		0x5549BF1FU, 0x3F76E38FU, 0x5420F4U,
-		{0x10, 0xB5, 0x01, 0x21, 0x5B, 0xF0, 0x42, 0xE0,
-		 0x04, 0x1C, 0x0D, 0xD0},
-	},
-	{
-		0xEAB89D5CU, 0xC1F30F67U, 0x535CF4U,
-		{0x10, 0xB5, 0x01, 0x21, 0x50, 0xF0, 0xFA, 0xE6,
-		 0x04, 0x1C, 0x0D, 0xD0},
-	},
+	{0x0552F692U,0xC1F30F67U,0x541B74U,0xCD679177U,0x45CA50U,{0x5B,0xF0,0x18,0xE7}},
+	{0x5549BF1FU,0x3F76E38FU,0x5420F4U,0x73F90499U,0x45CE98U,{0x5C,0xF0,0x3C,0xE1}},
+	{0xEAB89D5CU,0xC1F30F67U,0x535CF4U,0xCD679177U,0x452C08U,{0x51,0xF0,0xF4,0xE7}},
 };
 
 static const uint8_t expected_stop_entry[] = {
@@ -71,30 +90,41 @@ static const uint8_t stop_redirect_prefix[] = {
 };
 
 static const RecoveryProfile *active_profile;
-static SceUID ready_hook_id = -1;
-static tai_hook_ref_t ready_hook_ref;
-static SceUID stop_redirect_id = -1;
-static SceUID recovery_modid = -1;
+static SceUID load_call_id = -1, stop_redirect_id = -1, init_observer_id = -1;
+static atomic_int recovery_modid = -1;
 static RecoveryStop native_stop;
+static void (*native_init)(void *);
+static const uint32_t *action_flags;
 static SceUID patch_ids[ARRAY_COUNT(recovery_patches)];
-static volatile int lifecycle_busy;
-static int recovery_install_complete;
-static int initialized;
-static volatile unsigned int ready_in_flight;
+static int recovery_install_complete, initialized;
+static SceKernelLwMutexWork lifecycle_mutex;
+static atomic_uint load_in_flight, finish_in_flight, init_in_flight, stop_in_flight;
+static unsigned int pending_loads;
+enum { PRELOAD_IDLE, PRELOAD_PREPARING, PRELOAD_WAITING,
+	PRELOAD_RELEASING, PRELOAD_BLOCKED };
+static atomic_int preload_phase;
+static PafModule preload;
+static PafModule *(*module_acquire)(PafModule *, const char *, const char *, int, const void *);
+static PafModule *(*module_release)(PafModule *);
+static void *(*module_get_interface)(PafModule *,int);
+static void **framework_slot;
+static LoadAsync original_load;
+static LoadFinish original_finish;
 
 _Static_assert((RECOVERY_STOP_OFFSET & 3U) == 2U,
 	"stop redirect literal requires a halfword-aligned entry");
 _Static_assert(sizeof(stop_redirect_prefix) + sizeof(uint32_t) ==
 	sizeof(expected_stop_entry), "stop redirect must replace the complete entry");
 
+/* Never hold this mutex across a PAF constructor/destructor, load request or
+ * client callback. These may run callbacks or wait for another thread. */
 static int enter_lifecycle(void)
 {
-	return __sync_bool_compare_and_swap(&lifecycle_busy, 0, 1);
+	return sceKernelLockLwMutex(&lifecycle_mutex,1,NULL)>=0;
 }
-
 static void leave_lifecycle(void)
 {
-	__sync_lock_release(&lifecycle_busy);
+	sceKernelUnlockLwMutex(&lifecycle_mutex,1);
 }
 
 static void clear_patch_ids(void)
@@ -118,7 +148,23 @@ static int verify_recovery(const SceKernelModuleInfo *info)
 			RECOVERY_TEXT_SIZE, RECOVERY_DATA_SIZE);
 		return RECOVERY_ERROR;
 	}
+#if UINTPTR_MAX == UINT32_MAX
+	if((uintptr_t)info->segments[0].vaddr>=0xE0000000U ||
+		(uintptr_t)info->segments[1].vaddr>=0xE0000000U) {
+		debug_logf("recovery","validation-failed reason=shared-range-module");
+		return RECOVERY_ERROR;
+	}
+#endif
 	text = info->segments[0].vaddr;
+	static const uint32_t methods[] = {0x99,0x9B,0x15F,0x167,0x207};
+	for (unsigned int i=0;i<ARRAY_COUNT(methods);++i) {
+		uint32_t pointer;
+		memcpy(&pointer,(uint8_t *)info->segments[1].vaddr+i*4,4);
+		if (pointer!=(uint32_t)((uintptr_t)text+methods[i])) {
+			debug_logf("recovery","validation-failed reason=module-interface slot=%u",i);
+			return RECOVERY_ERROR;
+		}
+	}
 	if (memcmp(text + RECOVERY_STOP_OFFSET, expected_stop_entry,
 			sizeof(expected_stop_entry)) != 0) {
 		debug_logf("recovery", "validation-failed reason=stop-entry");
@@ -150,6 +196,12 @@ static int release_recovery_patches(void)
 {
 	int first_error = 0;
 	int index;
+	if (init_observer_id>=0) {
+		int result=taiInjectRelease(init_observer_id);
+		debug_logf("recovery","init-observer-release uid=%d result=%d",init_observer_id,result);
+		if (result>=0) init_observer_id=-1;
+		else first_error=result;
+	}
 
 	for (index = (int)ARRAY_COUNT(patch_ids) - 1; index >= 0; --index) {
 		if (patch_ids[index] >= 0) {
@@ -184,49 +236,43 @@ static void clear_recovery_state(void)
 {
 	recovery_modid = -1;
 	native_stop = NULL;
+	native_init = NULL;
+	action_flags = NULL;
 	recovery_install_complete = 0;
 }
 
-static int recovery_module_stop_redirect(SceSize args, const void *argp)
+static int recovery_module_stop_redirect(SceSize args,const void *argp)
 {
 	RecoveryStop stop;
-	int result;
-
-	debug_logf("recovery", "module-stop enter modid=%d args=%u argp=0x%08X native=0x%08X complete=%d",
-		recovery_modid, (unsigned int)args, (unsigned int)(uintptr_t)argp,
-		(unsigned int)(uintptr_t)native_stop, recovery_install_complete);
+	int result=SCE_KERNEL_STOP_CANCEL;
+	atomic_fetch_add(&stop_in_flight,1);
+	debug_logf("recovery","module-stop enter modid=%d args=%u argp=0x%08X",
+		recovery_modid,(unsigned int)args,(unsigned int)(uintptr_t)argp);
 	debug_log_flush();
-	if (!enter_lifecycle()) {
-		debug_logf("recovery", "module-stop cancelled reason=busy");
-		debug_log_flush();
-		return SCE_KERNEL_STOP_CANCEL;
+	if(!enter_lifecycle()) goto done;
+	if(!native_stop || init_in_flight || stop_in_flight>1) {
+		debug_logf("recovery","module-stop cancelled reason=callback-active-or-native-null");
+		leave_lifecycle();goto done;
 	}
-	if (native_stop == NULL) {
-		debug_logf("recovery", "module-stop cancelled reason=native-stop-null");
-		debug_log_flush();
-		leave_lifecycle();
-		return SCE_KERNEL_STOP_CANCEL;
+	if(release_recovery_patches()<0 || release_stop_redirect()<0) {
+		debug_logf("recovery","module-stop cancelled reason=cleanup-failed");
+		recovery_install_complete=0;preload_phase=PRELOAD_BLOCKED;
+		leave_lifecycle();goto done;
 	}
-	if (release_recovery_patches() < 0 || release_stop_redirect() < 0) {
-		debug_logf("recovery", "module-stop cancelled reason=cleanup-failed modid=%d redirect=%d",
-			recovery_modid, stop_redirect_id);
-		debug_log_flush();
-		leave_lifecycle();
-		return SCE_KERNEL_STOP_CANCEL;
-	}
-	stop = native_stop;
-	clear_recovery_state();
-	debug_logf("recovery", "module-stop native-enter address=0x%08X",
-		(unsigned int)(uintptr_t)stop);
+	stop=native_stop;clear_recovery_state();leave_lifecycle();
+	debug_logf("recovery","module-stop native-enter address=0x%08X",(unsigned int)(uintptr_t)stop);
 	debug_log_flush();
-	result = stop(args, argp);
-	debug_logf("recovery", "module-stop native-return result=%d", result);
-	debug_log_flush();
-	leave_lifecycle();
-	return result;
+	result=stop(args,argp);
+	debug_logf("recovery","module-stop native-return result=%d",result);
+done:
+	debug_log_flush();atomic_fetch_sub(&stop_in_flight,1);return result;
 }
 
-static int install_recovery(void)
+#if LIVEAREA_DEBUG_LOGGING
+static void recovery_init_observer(void *plugin);
+#endif
+
+static int install_recovery(SceUID expected_modid,const void *module_interface)
 {
 	tai_module_info_t module = {0};
 	SceKernelModuleInfo info = {0};
@@ -246,7 +292,8 @@ static int install_recovery(void)
 		result, result < 0 ? -1 : module.modid,
 		result < 0 ? 0U : (unsigned int)module.module_nid,
 		(unsigned int)active_profile->recovery_nid);
-	if (result < 0 || module.module_nid != active_profile->recovery_nid) {
+	if (result < 0 || module.modid != expected_modid ||
+		module.module_nid != active_profile->recovery_nid) {
 		debug_logf("recovery", "install-rejected reason=module-identity");
 		return RECOVERY_ERROR;
 	}
@@ -257,7 +304,7 @@ static int install_recovery(void)
 		(unsigned int)info.segments[0].memsz,
 		(unsigned int)(uintptr_t)info.segments[1].vaddr,
 		(unsigned int)info.segments[1].memsz);
-	if (result < 0 || verify_recovery(&info) < 0)
+	if (result < 0 || module_interface!=info.segments[1].vaddr || verify_recovery(&info) < 0)
 		return RECOVERY_ERROR;
 
 	memcpy(stop_redirect, stop_redirect_prefix, sizeof(stop_redirect_prefix));
@@ -273,6 +320,8 @@ static int install_recovery(void)
 	recovery_modid = module.modid;
 	native_stop = (RecoveryStop)((uintptr_t)info.segments[0].vaddr +
 		RECOVERY_STOP_OFFSET + 1U);
+	native_init=(void *)((uintptr_t)info.segments[0].vaddr+RECOVERY_INITIALIZER_OFFSET+1U);
+	action_flags=(void *)((uint8_t *)info.segments[1].vaddr+RECOVERY_ACTION_FLAGS_OFFSET);
 	clear_patch_ids();
 	for (index = 0; index < ARRAY_COUNT(recovery_patches); ++index) {
 		const RecoveryPatch *patch = &recovery_patches[index];
@@ -282,168 +331,283 @@ static int install_recovery(void)
 		debug_logf("recovery", "patch-injected index=%u offset=0x%08X size=%u uid=%d",
 			index, (unsigned int)patch->offset, patch->size, patch_ids[index]);
 		if (patch_ids[index] < 0) {
-			int release_result;
-
-			result = patch_ids[index];
-			patch_ids[index] = -1;
-			release_result = release_recovery_patches();
-			if (release_result >= 0)
-				release_result = release_stop_redirect();
-			if (release_result >= 0)
-				clear_recovery_state();
-			debug_logf("recovery", "install-rollback injection_result=%d cleanup_result=%d retained_modid=%d",
-				result, release_result, recovery_modid);
-			return result;
+			result=patch_ids[index];patch_ids[index]=-1;goto rollback;
 		}
 	}
+#if LIVEAREA_DEBUG_LOGGING
+	/* Observe the private module's initializer through its existing interface.
+	 * PAF copies this pointer before calling init. No entry trampoline is used. */
+	target=(uint32_t)(uintptr_t)recovery_init_observer|1U;
+	init_observer_id=taiInjectData(module.modid,1,4,&target,4);
+	debug_logf("recovery","init-observer-injected uid=%d",init_observer_id);
+	if (init_observer_id<0) {result=init_observer_id;goto rollback;}
+#endif
+
 	recovery_install_complete = 1;
 	debug_logf("recovery", "module-patched modid=%d stop-redirect=%d",
 		recovery_modid, stop_redirect_id);
 	debug_log_flush();
 	return 0;
+rollback:
+	{
+		int cleanup=release_recovery_patches();
+		if (cleanup>=0) cleanup=release_stop_redirect();
+		if (cleanup>=0) clear_recovery_state();
+		debug_logf("recovery","install-rollback result=%d cleanup=%d retained_modid=%d",
+			result,cleanup,recovery_modid);
+		debug_log_flush();return result;
+	}
 }
 
-static int recovery_ready_hook(void *plugin)
+
+#if LIVEAREA_DEBUG_LOGGING
+static uint32_t read_action_flags(void)
 {
-	int install_result = RECOVERY_ERROR;
-	int run_recovery = 0;
-	int result;
+	uint32_t flags=0;
+	if(enter_lifecycle()) {if(action_flags) flags=*action_flags;leave_lifecycle();}
+	return flags;
+}
 
-	__sync_add_and_fetch(&ready_in_flight, 1);
-	debug_logf("recovery", "ready-enter plugin=0x%08X modid=%d complete=%d",
-		(unsigned int)(uintptr_t)plugin, recovery_modid,
-		recovery_install_complete);
+static void recovery_init_observer(void *plugin)
+{
+	atomic_fetch_add(&init_in_flight,1);
+	debug_logf("recovery","init-enter plugin=0x%08X modid=%d patched=%d flags=0x%08X",
+		(unsigned int)(uintptr_t)plugin,recovery_modid,recovery_install_complete,
+		read_action_flags());
 	debug_log_flush();
+	native_init(plugin);
+	debug_logf("recovery","init-return flags=0x%08X",read_action_flags());
+	debug_log_flush();
+	atomic_fetch_sub(&init_in_flight,1);
+}
+#endif
 
-	if (enter_lifecycle()) {
-		if (recovery_modid < 0) {
-			install_result = install_recovery();
-		} else if (recovery_install_complete) {
-			install_result = 0;
+static int resolve_paf(void)
+{
+	tai_module_info_t module={0};
+	SceKernelModuleInfo info={0};
+	module.size=sizeof(module);info.size=sizeof(info);
+	if(taiGetModuleInfo("ScePaf",&module)<0 || module.module_nid!=active_profile->paf_nid ||
+		sceKernelGetModuleInfo(module.modid,&info)<0 ||
+		!info.segments[0].vaddr || info.segments[0].memsz!=0x300D00U ||
+		!info.segments[1].vaddr || info.segments[1].memsz<0xE000U) return RECOVERY_ERROR;
+	const uint8_t *text=info.segments[0].vaddr;
+	static const struct { uint32_t offset; unsigned int size; uint8_t bytes[12]; } checks[]={
+		{0x4722A,6,{0x2D,0xE9,0xF0,0x4F,0x8D,0xB0}},
+		{0x473D4,2,{0x70,0xB5}},
+		{0x472D0,10,{0xC8,0xF8,0x00,0x00,0xC2,0x69,0x01,0x32,0xC2,0x61}},
+		{0x473E6,8,{0x20,0x68,0xC1,0x69,0x01,0x39,0xC1,0x61}},
+		{0x471D8,10,{0x02,0x68,0x12,0x69,0x0A,0xB9,0x00,0x20,0x13,0xE0}},
+		{0x47218,6,{0x00,0x68,0x40,0x6A,0x70,0x47}},
+		{0x54580,4,{0x40,0x6D,0x70,0x47}},
+		{0x58E5E,10,{0x31,0x6A,0x09,0xB1,0x30,0x1C,0x88,0x47,0x01,0x20}},
+	};
+	for(unsigned int i=0;i<ARRAY_COUNT(checks);++i)
+		if(memcmp(text+checks[i].offset,checks[i].bytes,checks[i].size)) return RECOVERY_ERROR;
+	framework_slot=(void *)((uint8_t *)info.segments[1].vaddr+0x194U);
+	if(!*framework_slot) return RECOVERY_ERROR;
+	module_acquire=(void *)((uintptr_t)text+0x4722BU);
+	module_release=(void *)((uintptr_t)text+0x473D5U);
+	module_get_interface=(void *)((uintptr_t)text+0x471D9U);
+	debug_logf("recovery","paf-validated nid=0x%08X text=0x%08X module-acquire=0x%08X",
+		module.module_nid,(unsigned int)(uintptr_t)text,(unsigned int)(uintptr_t)module_acquire);
+	return 0;
+}
+
+static int matches_string(const PafString *str,const char *expected,unsigned int length)
+{
+	return str->data && str->length==length && !memcmp(str->data,expected,length+1);
+}
+static int matches_request(const PafLoadParam *param,LoadFinish finish)
+{
+	static const char name[]="dbrecovery_plugin";
+	static const char file[]="vs0:vsh/common/dbrecovery_plugin.suprx";
+	return param && finish==original_finish && param->module_interface_version==1 &&
+		param->module_option==1 && matches_string(&param->name,name,sizeof(name)-1) &&
+		matches_string(&param->module_file,file,sizeof(file)-1);
+}
+
+static void recovery_load_finished(void *plugin)
+{
+	int release=0;
+	atomic_fetch_add(&finish_in_flight,1);
+	debug_logf("recovery","load-finished plugin=0x%08X modid=%d flags=0x%08X",
+		(unsigned int)(uintptr_t)plugin,recovery_modid,read_action_flags());
+	/* The callback owns a valid Plugin until the client callback is invoked.
+	 * Check ModuleImpl reuse now; the client may itself unload the Plugin. */
+	if(enter_lifecycle()) {
+		if(plugin && preload.impl) {
+			PafModule *owner;
+			memcpy(&owner,(uint8_t *)plugin+48,sizeof(owner));
+			if(!owner || owner->impl!=preload.impl) {
+				preload_phase=PRELOAD_BLOCKED;
+				debug_logf("recovery","preload-owner-mismatch reference-retained=1");
+			}
 		}
-		run_recovery = recovery_install_complete || recovery_modid < 0;
 		leave_lifecycle();
-	} else {
-		debug_logf("recovery", "ready-blocked reason=busy");
 	}
-	debug_logf("recovery", "ready-callback install-result=%d modid=%d run_native=%d patched=%d",
-		install_result, recovery_modid, run_recovery, recovery_install_complete);
+	debug_logf("recovery","finish-native-enter callback=0x%08X",
+		(unsigned int)(uintptr_t)original_finish);
 	debug_log_flush();
-	(void)install_result;
-	if (!run_recovery) {
-		debug_logf("recovery", "ready-blocked reason=incomplete-or-busy");
+	original_finish(plugin);
+	debug_logf("recovery","finish-native-return");
+	debug_log_flush();
+	if(enter_lifecycle()) {
+		if(pending_loads) --pending_loads;
+		else debug_logf("recovery","finish-unbalanced reference-retained=1");
+		if(!pending_loads && preload_phase==PRELOAD_WAITING && preload.impl) {
+			preload_phase=PRELOAD_RELEASING;release=1;
+		}
+		leave_lifecycle();
+	}
+	if(release) {
+		/* May stop/unload the module on a failed Plugin load. Keep all locks
+		 * released so the private stop redirect can restore its patches. */
+		debug_logf("recovery","preload-release modid=%d",preload.impl->handle);
 		debug_log_flush();
-		__sync_sub_and_fetch(&ready_in_flight, 1);
-		return RECOVERY_ERROR;
+		module_release(&preload);
+		preload.impl=NULL; /* RELEASING excludes another writer. */
+		if(enter_lifecycle()) {
+			if(preload_phase!=PRELOAD_BLOCKED) preload_phase=PRELOAD_IDLE;
+			leave_lifecycle();
+		}
+		debug_logf("recovery","preload-released");
 	}
-	debug_logf("recovery", "ready-native-enter");
 	debug_log_flush();
-	result = TAI_CONTINUE(int, ready_hook_ref, plugin);
-	debug_logf("recovery", "ready-native-return result=%d", result);
+	atomic_fetch_sub(&finish_in_flight,1);
+}
+
+/* Called only after reserving PREPARING and validating the PAF helpers.
+ * Returns 1 with a retained preload, 0 for native fallback, -1 when blocked. */
+static int prepare_recovery_module(const PafLoadParam *param)
+{
+	int installed=RECOVERY_ERROR,mode;
+	if(recovery_modid<0) {
+		tai_module_info_t existing={0};existing.size=sizeof(existing);
+		if(taiGetModuleInfo("SceDbRecovery",&existing)>=0) {
+			debug_logf("recovery","preload-skipped reason=untracked-existing-module modid=%d",existing.modid);
+			return 0;
+		}
+	}
+	memcpy(&mode,(uint8_t *)*framework_slot+84,sizeof(mode));
+	int module_option=param->module_option|(mode==5?2:0);
+	debug_logf("recovery","preload-enter module-option=%d",module_option);
 	debug_log_flush();
-	__sync_sub_and_fetch(&ready_in_flight, 1);
-	return result;
+	module_acquire(&preload,param->module_file.data,NULL,module_option,NULL);
+	debug_logf("recovery","preload-return impl=0x%08X modid=%d result=%d",
+		(unsigned int)(uintptr_t)preload.impl,preload.impl?preload.impl->handle:-1,
+		preload.impl?preload.impl->result:RECOVERY_ERROR);
+	debug_log_flush();
+	if(!preload.impl || preload.impl->result || preload.impl->handle<=0) {
+		/* A retained failed ModuleImpl would poison native LoadAsync retries. */
+		if(preload.impl) module_release(&preload);
+		preload.impl=NULL;return 0;
+	}
+	const void *module_interface=module_get_interface(&preload,param->module_interface_version);
+	if(!module_interface) {
+		debug_logf("recovery","preload-skipped reason=missing-module-interface");
+		module_release(&preload);preload.impl=NULL;return 0;
+	}
+	if(!enter_lifecycle()) return -1;
+	if(recovery_modid<0) installed=install_recovery(preload.impl->handle,module_interface);
+	else if(recovery_modid==preload.impl->handle && recovery_install_complete) installed=0;
+	if(installed<0 && recovery_modid>=0) {
+		preload_phase=PRELOAD_BLOCKED;leave_lifecycle();return -1;
+	}
+	pending_loads=1;preload_phase=PRELOAD_WAITING;
+	leave_lifecycle();
+	debug_logf("recovery","preload-prepared patched=%u before-initializer=1",installed==0);
+	debug_log_flush();return 1;
+}
+
+static void recovery_load_hook(const PafLoadParam *param,LoadFinish finish,int option)
+{
+	atomic_fetch_add(&load_in_flight,1);
+	if(!matches_request(param,finish)) {
+		debug_logf("recovery","load-passthrough reason=request-mismatch");
+		original_load(param,finish,option);goto done;
+	}
+	if(!enter_lifecycle()) goto blocked;
+	if(stop_in_flight) {leave_lifecycle();goto blocked;}
+	if(preload_phase==PRELOAD_WAITING) {
+		++pending_loads;leave_lifecycle();
+		original_load(param,recovery_load_finished,option);goto done;
+	}
+	if(preload_phase!=PRELOAD_IDLE || stop_in_flight) {leave_lifecycle();goto blocked;}
+	preload_phase=PRELOAD_PREPARING;leave_lifecycle();
+	if(resolve_paf()<0) {
+		debug_logf("recovery","preload-skipped reason=paf-validation");goto fallback;
+	}
+	int prepared=prepare_recovery_module(param);
+	if(prepared<0) goto blocked;
+	if(!prepared) goto fallback;
+	debug_logf("recovery","load-native-enter");debug_log_flush();
+	original_load(param,recovery_load_finished,option);
+	debug_logf("recovery","load-native-return");goto done;
+fallback:
+	if(enter_lifecycle()) {
+		preload_phase=PRELOAD_IDLE;leave_lifecycle();
+		original_load(param,finish,option);goto done;
+	}
+blocked:
+	debug_logf("recovery","load-blocked phase=%d retained-modid=%d",preload_phase,recovery_modid);
+	debug_log_flush();
+done:
+	atomic_fetch_sub(&load_in_flight,1);
+}
+
+static void encode_mov(uint8_t *p,unsigned int op,unsigned int reg,uint16_t value)
+{
+	uint16_t a=op|(value>>12)|((value>>1)&0x400), b=((value<<4)&0x7000)|(reg<<8)|(value&255);
+	p[0]=a;p[1]=a>>8;p[2]=b;p[3]=b>>8;
+}
+
+int recovery_start(SceUID shell_modid,uint32_t shell_nid,const SceKernelModuleInfo *info)
+{
+	if(initialized) return RECOVERY_ERROR;
+	active_profile=NULL;
+	for(unsigned int i=0;i<ARRAY_COUNT(recovery_profiles);++i)
+		if(recovery_profiles[i].shell_nid==shell_nid) active_profile=&recovery_profiles[i];
+	if(!active_profile || !info || !info->segments[0].vaddr ||
+		info->segments[0].memsz!=active_profile->shell_text_size) return RECOVERY_ERROR;
+	uintptr_t base=(uintptr_t)info->segments[0].vaddr;
+	if(base&3U) return RECOVERY_ERROR;
+	uint8_t expected[16]={0,0,0,0,0x08,0xA8,0,0,0,0,0x00,0x22,0,0,0,0},call[4];
+	uintptr_t callback=base+SHELL_RECOVERY_READY_OFFSET+1U;
+	encode_mov(expected,0xF240,1,(uint16_t)callback);
+	encode_mov(expected+6,0xF2C0,1,(uint16_t)(callback>>16));
+	memcpy(expected+12,active_profile->load_call,4);
+	if(memcmp((void *)(base+SHELL_RECOVERY_LOAD_CALL_OFFSET-12),expected,sizeof(expected)) ||
+		shell_detour_encode_call(call,base+SHELL_RECOVERY_LOAD_CALL_OFFSET,(uintptr_t)recovery_load_hook|1U)<0) {
+		debug_logf("recovery","start-rejected reason=load-call-validation");return RECOVERY_ERROR;
+	}
+	int result=sceKernelCreateLwMutex(&lifecycle_mutex,"LiveAreaNoLimitsRecovery",0,0,NULL);
+	if(result<0) return result;
+	initialized=1;clear_patch_ids();
+	original_load=(void *)(base+active_profile->load_import);
+	original_finish=(void *)callback;
+	load_call_id=taiInjectData(shell_modid,0,SHELL_RECOVERY_LOAD_CALL_OFFSET,call,sizeof(call));
+	debug_logf("recovery","load-call-installed uid=%d offset=0x%08X original=0x%08X ready-entry-unmodified=1",
+		load_call_id,SHELL_RECOVERY_LOAD_CALL_OFFSET,(unsigned int)(uintptr_t)original_load);
+	debug_log_flush();
+	if(load_call_id<0) {
+		result=load_call_id;sceKernelDeleteLwMutex(&lifecycle_mutex);initialized=0;
+		return result;
+	}
+	return 0;
 }
 
 int recovery_stop(void)
 {
-	int result = 0;
-
-	debug_logf("recovery", "plugin-stop initialized=%d modid=%d redirect=%d ready_hook=%d",
-		initialized, recovery_modid, stop_redirect_id, ready_hook_id);
-	if (!initialized)
-		return 0;
-	if (!enter_lifecycle()) {
-		debug_logf("recovery", "plugin-stop blocked reason=busy");
+	if(!initialized) return 0;
+	/* As with the per-instance cache, a live SceShell call site can dispatch
+	 * callbacks later. Switch builds by reboot, never by hot-unloading it. */
+	if(load_call_id>=0 || load_in_flight || finish_in_flight || init_in_flight || stop_in_flight ||
+		preload.impl || recovery_modid>=0 || stop_redirect_id>=0) {
+		debug_logf("recovery","plugin-stop cancelled reason=live-call-site-or-module");
 		return RECOVERY_ERROR;
 	}
-	if (recovery_modid >= 0 || stop_redirect_id >= 0 || ready_in_flight != 0) {
-		debug_logf("recovery", "plugin-stop blocked reason=module-or-callback-active callbacks=%u",
-			(unsigned int)ready_in_flight);
-		leave_lifecycle();
-		return RECOVERY_ERROR;
-	}
-	if (ready_hook_id >= 0) {
-		result = taiHookRelease(ready_hook_id, ready_hook_ref);
-		debug_logf("recovery", "ready-hook-release uid=%d result=%d", ready_hook_id, result);
-		if (result >= 0)
-			ready_hook_id = -1;
-	}
-	if (result >= 0) {
-		active_profile = NULL;
-		initialized = 0;
-	}
-	leave_lifecycle();
-	debug_logf("recovery", "plugin-stop return=%d initialized=%d", result, initialized);
-	debug_log_flush();
+	int result=sceKernelDeleteLwMutex(&lifecycle_mutex);
+	if(result>=0) initialized=0;
 	return result;
-}
-
-int recovery_start(SceUID shell_modid, uint32_t shell_nid,
-	const SceKernelModuleInfo *shell_info)
-{
-	const uint8_t *text;
-	unsigned int index;
-
-	debug_logf("recovery", "start shell_modid=%d shell_nid=0x%08X initialized=%d hook=0x%08X stop_redirect=0x%08X",
-		shell_modid, (unsigned int)shell_nid, initialized,
-		(unsigned int)(uintptr_t)recovery_ready_hook,
-		(unsigned int)(uintptr_t)recovery_module_stop_redirect);
-	if (initialized) {
-		debug_logf("recovery", "start-rejected reason=already-initialized");
-		return RECOVERY_ERROR;
-	}
-	active_profile = NULL;
-	for (index = 0; index < ARRAY_COUNT(recovery_profiles); ++index) {
-		if (recovery_profiles[index].shell_nid == shell_nid) {
-			active_profile = &recovery_profiles[index];
-			break;
-		}
-	}
-	if (active_profile == NULL) {
-		debug_logf("recovery", "start-rejected reason=profile-missing");
-		goto fail;
-	}
-	debug_logf("recovery", "profile-selected recovery_nid=0x%08X expected_text=0x%08X",
-		(unsigned int)active_profile->recovery_nid,
-		(unsigned int)active_profile->shell_text_size);
-	if (shell_info == NULL ||
-		shell_info->segments[0].vaddr == NULL ||
-		shell_info->segments[0].memsz != active_profile->shell_text_size) {
-		debug_logf("recovery", "start-rejected reason=shell-segment");
-		goto fail;
-	}
-	text = shell_info->segments[0].vaddr;
-	if (memcmp(text + SHELL_RECOVERY_READY_OFFSET,
-		active_profile->ready_prefix, sizeof(active_profile->ready_prefix)) != 0) {
-		debug_logf("recovery", "start-rejected reason=ready-bytes");
-		debug_log_hex("recovery", "ready-actual", SHELL_RECOVERY_READY_OFFSET,
-			text + SHELL_RECOVERY_READY_OFFSET, sizeof(active_profile->ready_prefix));
-		debug_log_hex("recovery", "ready-expected", SHELL_RECOVERY_READY_OFFSET,
-			active_profile->ready_prefix, sizeof(active_profile->ready_prefix));
-		goto fail;
-	}
-
-	/* SceShell code is process-local; shared-library lifecycle hooks are not. */
-	ready_hook_id = taiHookFunctionOffset(&ready_hook_ref, shell_modid, 0,
-		SHELL_RECOVERY_READY_OFFSET, 1, recovery_ready_hook);
-	debug_logf("recovery", "ready-hook-install result=%d offset=0x%08X",
-		ready_hook_id, SHELL_RECOVERY_READY_OFFSET);
-	if (ready_hook_id < 0)
-		goto fail;
-	clear_patch_ids();
-	stop_redirect_id = -1;
-	clear_recovery_state();
-	initialized = 1;
-	debug_logf("recovery", "ready-hook uid=%d offset=0x%08X",
-		ready_hook_id, SHELL_RECOVERY_READY_OFFSET);
-	debug_log_flush();
-	return 0;
-
-fail:
-	debug_logf("recovery", "start-failed baseline-capacity-retained");
-	debug_log_flush();
-	active_profile = NULL;
-	ready_hook_id = -1;
-	return RECOVERY_ERROR;
 }

--- a/src/shell_detour.c
+++ b/src/shell_detour.c
@@ -30,3 +30,10 @@ SceUID shell_detour_install(SceUID module, uint32_t offset,
 		return -1;
 	return taiInjectData(module, 0, offset, branch, sizeof(branch));
 }
+
+int shell_detour_encode_call(uint8_t out[4], uintptr_t source, uintptr_t target)
+{
+	int result=shell_detour_encode_branch(out,source,target);
+	if(result>=0) out[3]|=0x40; /* B.W T4 -> BL T1; same displacement, sets LR. */
+	return result;
+}

--- a/src/shell_detour.h
+++ b/src/shell_detour.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <psp2/types.h>
 int shell_detour_encode_branch(uint8_t out[4], uintptr_t source, uintptr_t target);
+int shell_detour_encode_call(uint8_t out[4], uintptr_t source, uintptr_t target);
 SceUID shell_detour_install(SceUID module, uint32_t offset,
     uintptr_t source, const void *target);
 #endif

--- a/tests/arm_helpers.py
+++ b/tests/arm_helpers.py
@@ -51,23 +51,24 @@ def word(u, address, value):
     u.mem_write(address, struct.pack("<I", value))
 
 
-def encode(u, symbols, source, target):
+def encode(u, symbols, source, target, function="shell_detour_encode_branch"):
     u.reg_write(reg.UC_ARM_REG_R0, HEAP + 0x8000)
     u.reg_write(reg.UC_ARM_REG_R1, source)
     u.reg_write(reg.UC_ARM_REG_R2, target)
     u.reg_write(reg.UC_ARM_REG_LR, RETURN | 1)
-    u.emu_start(symbols["shell_detour_encode_branch"] | 1, RETURN, count=200)
+    u.emu_start(symbols[function] | 1, RETURN, count=200)
     assert u.reg_read(reg.UC_ARM_REG_PC) == RETURN
     return u.reg_read(reg.UC_ARM_REG_R0), bytes(u.mem_read(HEAP + 0x8000, 4))
 
 
-def check_encoder(plugin):
+def check_encoder(plugin, link=False):
     u = machine(plugin)
     source = 0x81880002
+    function = "shell_detour_encode_call" if link else "shell_detour_encode_branch"
     cases = 0
     for delta in [-16777216, -16777214, -4096, -2, 0, 2, 4094, 16777214]:
         target = source + 4 + delta
-        result, code = encode(u, plugin[2], source, target | 1)
+        result, code = encode(u, plugin[2], source, target | 1, function)
         assert result == 0
         # Execute the emitted instruction, even for a distant target. Stop at
         # that target before any instruction there needs to be meaningful.
@@ -80,11 +81,12 @@ def check_encoder(plugin):
         u.ctl_remove_cache(source, source + 4)
         u.emu_start(source | 1, target, count=1)
         assert u.reg_read(reg.UC_ARM_REG_PC) == target, (delta, code.hex(), hex(target), hex(u.reg_read(reg.UC_ARM_REG_PC)))
+        if link: assert u.reg_read(reg.UC_ARM_REG_LR) == (source + 4) | 1
         cases += 1
     for src, target in [(source, source + 4 - 16777218 | 1),
                         (source, source + 4 + 16777216 | 1),
                         (source | 1, source + 9), (source, source + 8),
                         (0xFFFFFFFE, 1)]:
-        assert encode(u, plugin[2], src, target)[0] == 0xFFFFFFFF
+        assert encode(u, plugin[2], src, target, function)[0] == 0xFFFFFFFF
         cases += 1
     return cases

--- a/tests/run.py
+++ b/tests/run.py
@@ -191,24 +191,9 @@ with tempfile.TemporaryDirectory(prefix="livearea-tests-") as temporary:
                 subprocess.run([str(hook_test), paf, offsets["PAF_EVICT_OFFSET"],
                                 offsets["PAF_SCAN_OFFSET"], shell, init_offset,
                                 offsets["PAF_APPLY_OFFSET"]], check=True)
-        recovery_offsets = dict(re.findall(
-            r"#define\s+(SHELL_RECOVERY_READY_OFFSET)\s+(0x[0-9A-Fa-f]+)U",
-            (root / "src/recovery.c").read_text()))
-        recovery_hook_test = work / "test_recovery_hook_transform"
-        subprocess.run(shlex.split(os.environ.get("CC", "cc")) + [
-            "-std=gnu11", "-DFORCE_TARGET_arm",
-            "-I", str(substitute / "lib"), "-I", str(substitute / "generated"),
-            str(root / "tests/test_recovery_hook_transform.c"),
-            str(substitute / "lib/jump-dis.c"),
-            str(substitute / "lib/cbit/vec.c"),
-            str(substitute / "lib/strerror.c"),
-            "-o", str(recovery_hook_test)], check=True)
-        for nid, _, shell, _ in cache_inputs:
-            if shell:
-                print(f"Recovery callback relocator profile: 0x{nid:08X}", flush=True)
-                subprocess.run([str(recovery_hook_test), shell,
-                                recovery_offsets["SHELL_RECOVERY_READY_OFFSET"]],
-                               check=True)
+        # Current recovery interception uses a checked BL call-site rewrite,
+        # not a libsubstitute function trampoline. The old ready-entry hook is
+        # intentionally absent; its replacement is tested by the ARM preload harness.
     arm_python = os.environ.get("LIVEAREA_TEST_ARM_PYTHON")
     if arm_python:
         subprocess.run([arm_python, str(root / "tests/test_recovery_stop_redirect.py")],

--- a/tests/stubs/psp2/kernel/threadmgr/lw_mutex.h
+++ b/tests/stubs/psp2/kernel/threadmgr/lw_mutex.h
@@ -2,6 +2,9 @@
 #define TEST_LW_MUTEX_H
 #include <psp2/types.h>
 typedef struct { int data[8]; } SceKernelLwMutexWork;
+int sceKernelCreateLwMutex(SceKernelLwMutexWork *,const char *,unsigned int,int,void *);
+int sceKernelDeleteLwMutex(SceKernelLwMutexWork *);
+int sceKernelLockLwMutex(SceKernelLwMutexWork *,int,unsigned int *);
 int sceKernelTryLockLwMutex(SceKernelLwMutexWork *,int);
 int sceKernelUnlockLwMutex(SceKernelLwMutexWork *,int);
 #endif

--- a/tests/test_recovery.c
+++ b/tests/test_recovery.c
@@ -1,870 +1,255 @@
+/* Host lifecycle checks. Native PAF/OS services are modeled; the separate ARM
+ * harness executes compiled entry/continuation and native firmware code. */
 #include <assert.h>
-#include <stdarg.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <psp2/kernel/modulemgr.h>
-#include <psp2/types.h>
-#include <taihen.h>
-
+#include "../src/recovery.c"
 #if LIVEAREA_DEBUG_LOGGING
 #include "debug_capture.h"
 #endif
 
-extern const uint8_t patch_cmp_r0_icon_limit[4];
-extern const uint8_t patch_rsbs_r1_r0_icon_limit[4];
-extern const uint8_t patch_cmp_r4_page_limit[2];
-extern const uint8_t patch_movs_r9_last_page[4];
-
-enum Event {
-	EVENT_HOOK_INSTALL,
-	EVENT_INJECT,
-	EVENT_CONTINUE,
-	EVENT_INJECT_RELEASE,
-	EVENT_NATIVE_STOP,
-	EVENT_HOOK_RELEASE,
-};
-
-typedef struct {
-	SceUID uid;
-	tai_hook_ref_t ref;
-	SceUID modid;
-	uint32_t offset;
-	const void *function;
-	int live;
-} HookRecord;
-
-typedef struct {
-	SceUID uid;
-	uint32_t offset;
-	SceSize size;
-	uint8_t original[10];
-	int live;
-} InjectionRecord;
-
-static enum Event events[128];
-static unsigned int event_count;
-static HookRecord hooks[16];
-static unsigned int hook_count;
-static unsigned int hook_install_calls;
-static int hook_install_failure_call;
-static SceUID hook_release_failure_uid;
-static unsigned int hook_release_calls;
-static SceUID hook_release_order[16];
-static unsigned int import_hook_calls;
-static InjectionRecord injections[16];
-static unsigned int injection_count;
-static unsigned int injection_attempts;
-static int injection_failure_call;
-static SceUID injection_release_failure_uid;
-static unsigned int injection_release_calls;
-static SceUID injection_release_order[16];
-static unsigned int continue_calls;
-static tai_hook_ref_t continue_order[16];
-static int ready_original_result;
-static int unload_during_ready;
-static unsigned int native_stop_calls;
-static int native_stop_result;
-static SceSize native_stop_args;
-static const void *native_stop_argp;
-static int recovery_available;
-static int module_info_failure;
-static SceUID reported_recovery_modid;
-static uint32_t reported_recovery_nid;
-static int recovery_text_null;
-static int recovery_data_null;
-static int recovery_text_size_delta;
-static int recovery_data_size_delta;
-static uint8_t *shell_text;
-static uint8_t *recovery_text;
-static uint8_t *recovery_original;
-static uint8_t *recovery_data;
+static uint8_t *shell_text,*module_text,*module_data,*paf_text,*paf_data;
 static SceKernelModuleInfo shell_info;
+static const RecoveryProfile *fixture_profile;
+static PafModuleImpl impl;
+static PafModule owner;
+static struct { uint8_t before_module[48]; PafModule *module; } plugin;
+static unsigned int mutex_depth,mutex_created,acquires,releases,starts,stops,finishes,loads,inits;
+static int available,ctor_error,info_error,bad_nid,create_error,owner_unloads,finish_reenters;
+static int fail_injection,fail_release,attempts;
+static uint32_t fake_framework[32];
+static void *fake_framework_ptr=fake_framework;
+static LoadFinish queued[8];
+static unsigned int queued_count;
+static struct { int live; uint8_t *destination; uint8_t original[10]; unsigned int size; } injections[32];
+static PafLoadParam param;
 
-#include "../src/recovery.c"
-
-static void record_event(enum Event event)
+int sceKernelCreateLwMutex(SceKernelLwMutexWork *w,const char *n,unsigned int a,int count,void *o)
+{ assert(w==&lifecycle_mutex && n && !a && !count && !o); if(create_error)return -9;mutex_created=1;return 0; }
+int sceKernelDeleteLwMutex(SceKernelLwMutexWork *w)
+{ assert(w==&lifecycle_mutex && !mutex_depth);mutex_created=0;return 0; }
+int sceKernelLockLwMutex(SceKernelLwMutexWork *w,int count,unsigned int *timeout)
+{ assert(w==&lifecycle_mutex && count==1 && !timeout && mutex_created && !mutex_depth);mutex_depth=1;return 0; }
+int sceKernelUnlockLwMutex(SceKernelLwMutexWork *w,int count)
+{ assert(w==&lifecycle_mutex && count==1 && mutex_depth==1);mutex_depth=0;return 0; }
+int shell_detour_encode_call(uint8_t out[4],uintptr_t from,uintptr_t to)
+{ assert(from==(uintptr_t)shell_text+SHELL_RECOVERY_LOAD_CALL_OFFSET);assert(to==((uintptr_t)recovery_load_hook|1));memset(out,0xCC,4);return 0; }
+int taiGetModuleInfo(const char *name,tai_module_info_t *m)
 {
-	assert(event_count < sizeof(events) / sizeof(events[0]));
-	events[event_count++] = event;
+ assert(m->size==sizeof(*m));
+ if(!strcmp(name,"ScePaf")) {m->modid=90;m->module_nid=fixture_profile->paf_nid;return 0;}
+ assert(!strcmp(name,"SceDbRecovery"));if(!available)return -1;
+ m->modid=42;m->module_nid=bad_nid?0:fixture_profile->recovery_nid;return 0;
 }
-
-int taiGetModuleInfo(const char *name, tai_module_info_t *info)
+int sceKernelGetModuleInfo(SceUID id,SceKernelModuleInfo *info)
 {
-	assert(strcmp(name, "SceDbRecovery") == 0);
-	assert(info->size == sizeof(*info));
-	if (!recovery_available)
-		return -1;
-	info->modid = reported_recovery_modid;
-	info->module_nid = reported_recovery_nid;
-	return 0;
+ assert(info->size==sizeof(*info));
+ if(id==90) {info->segments[0].vaddr=paf_text;info->segments[0].memsz=0x300D00;info->segments[1].vaddr=paf_data;info->segments[1].memsz=0x166D0;return 0;}
+ assert(id==42);if(info_error)return -1;
+ info->segments[0].vaddr=module_text;info->segments[0].memsz=RECOVERY_TEXT_SIZE;
+ info->segments[1].vaddr=module_data;info->segments[1].memsz=RECOVERY_DATA_SIZE;return 0;
 }
-
-SceUID taiInjectData(SceUID modid, int segment, uint32_t offset,
-	const void *data, SceSize size)
+SceUID taiInjectData(SceUID id,int segment,uint32_t offset,const void *data,SceSize size)
 {
-	unsigned int attempt = injection_attempts++;
-	InjectionRecord *record;
-
-	assert(modid == reported_recovery_modid && segment == 0);
-	assert(attempt <= ARRAY_COUNT(recovery_patches));
-	if (attempt == 0) {
-		uint32_t target;
-
-		assert(offset == RECOVERY_STOP_OFFSET);
-		assert(size == sizeof(expected_stop_entry));
-		assert(memcmp(data, stop_redirect_prefix,
-			sizeof(stop_redirect_prefix)) == 0);
-		memcpy(&target, (const uint8_t *)data +
-			sizeof(stop_redirect_prefix), sizeof(target));
-		assert(target == ((uint32_t)(uintptr_t)
-			recovery_module_stop_redirect | 1U));
-		assert(memcmp(recovery_text + offset, expected_stop_entry,
-			sizeof(expected_stop_entry)) == 0);
-	} else {
-		const RecoveryPatch *patch = &recovery_patches[attempt - 1];
-
-		assert(offset == patch->offset && size == patch->size);
-		assert(data == patch->replacement);
-		assert(memcmp(recovery_text + offset, patch->expected, size) == 0);
-	}
-	if ((int)attempt == injection_failure_call)
-		return -100 - (int)attempt;
-	assert(injection_count < ARRAY_COUNT(injections));
-	record = &injections[injection_count++];
-	record->uid = 500 + (SceUID)attempt;
-	record->offset = offset;
-	record->size = size;
-	memcpy(record->original, recovery_text + offset, size);
-	memcpy(recovery_text + offset, data, size);
-	record->live = 1;
-	record_event(EVENT_INJECT);
-	return record->uid;
+ int call=attempts++;assert(call<32 && size<=10);
+ if(call==fail_injection)return -100-call;
+ uint8_t *destination;
+ if(id==7) {assert(segment==0 && offset==SHELL_RECOVERY_LOAD_CALL_OFFSET && size==4);destination=shell_text+offset;}
+ else {assert(id==42 && available && mutex_depth==1);destination=(segment?module_data:module_text)+offset;}
+ injections[call].live=1;injections[call].destination=destination;injections[call].size=size;
+ memcpy(injections[call].original,destination,size);memcpy(destination,data,size);return 100+call;
 }
-
-int taiInjectRelease(SceUID uid)
+int taiInjectRelease(SceUID id)
 {
-	unsigned int index;
-
-	assert(injection_release_calls < ARRAY_COUNT(injection_release_order));
-	injection_release_order[injection_release_calls++] = uid;
-	record_event(EVENT_INJECT_RELEASE);
-	if (uid == injection_release_failure_uid)
-		return -200;
-	for (index = 0; index < injection_count; ++index) {
-		InjectionRecord *record = &injections[index];
-
-		if (record->uid == uid) {
-			assert(record->live);
-			memcpy(recovery_text + record->offset, record->original,
-				record->size);
-			record->live = 0;
-			return 0;
-		}
-	}
-	assert(0);
-	return -1;
+ assert(id>=100 && id<132);if(id==fail_release)return -9;
+ unsigned int i=id-100;assert(injections[i].live);memcpy(injections[i].destination,injections[i].original,injections[i].size);injections[i].live=0;return 0;
 }
-
-SceUID taiHookFunctionImport(tai_hook_ref_t *ref, const char *module,
-	uint32_t library, uint32_t nid, const void *hook)
+static int all_capacity_live(void)
 {
-	(void)ref;
-	(void)module;
-	(void)library;
-	(void)nid;
-	(void)hook;
-	++import_hook_calls;
-	return -1;
+ for(unsigned int i=0;i<ARRAY_COUNT(patch_ids);++i)if(patch_ids[i]<0)return 0;
+ return 1;
 }
-
-SceUID taiHookFunctionOffset(tai_hook_ref_t *ref, SceUID modid, int segment,
-	uint32_t offset, int thumb, const void *hook)
+static int mock_stop(SceSize argc,const void *argv)
 {
-	unsigned int call = hook_install_calls++;
-	HookRecord *record;
-
-	assert(segment == 0 && thumb == 1);
-	if ((int)call == hook_install_failure_call)
-		return -300 - (int)call;
-	assert(hook_count < ARRAY_COUNT(hooks));
-	record = &hooks[hook_count];
-	record->uid = 300 + (SceUID)hook_count;
-	record->ref = 0x1000U + hook_count;
-	record->modid = modid;
-	record->offset = offset;
-	record->function = hook;
-	record->live = 1;
-	*ref = record->ref;
-	++hook_count;
-	record_event(EVENT_HOOK_INSTALL);
-	return record->uid;
+ assert(!argc && !argv && !mutex_depth && !all_capacity_live() && init_observer_id<0);
+ ++stops;available=0;return 0;
 }
-
-int taiHookRelease(SceUID uid, tai_hook_ref_t ref)
+static PafModule *mock_acquire(PafModule *m,const char *name,const char *function,int option,const void *extra)
 {
-	unsigned int index;
-
-	assert(hook_release_calls < ARRAY_COUNT(hook_release_order));
-	hook_release_order[hook_release_calls++] = uid;
-	record_event(EVENT_HOOK_RELEASE);
-	if (uid == hook_release_failure_uid)
-		return -400;
-	for (index = 0; index < hook_count; ++index) {
-		HookRecord *record = &hooks[index];
-
-		if (record->uid == uid) {
-			assert(record->live && record->ref == ref);
-			record->live = 0;
-			return 0;
-		}
-	}
-	assert(0);
-	return -1;
+ assert(!mutex_depth && !strcmp(name,"vs0:vsh/common/dbrecovery_plugin.suprx") && !function && !extra);
+ assert(option==(fake_framework[21]==5?3:1));++acquires;
+ if(!impl.references) {++starts;available=1;impl.handle=42;impl.result=ctor_error;impl.option=option;}
+ ++impl.references;m->impl=&impl;return m;
 }
-
-int test_tai_continue(tai_hook_ref_t ref, ...)
+static PafModule *mock_release(PafModule *m)
 {
-	unsigned int index;
-	int result = 0;
-
-	assert(continue_calls < ARRAY_COUNT(continue_order));
-	continue_order[continue_calls++] = ref;
-	record_event(EVENT_CONTINUE);
-	for (index = 0; index < hook_count; ++index) {
-		if (hooks[index].ref != ref)
-			continue;
-		assert(hooks[index].offset == SHELL_RECOVERY_READY_OFFSET);
-		if (unload_during_ready) {
-			/* Even an unpatched fallback still executes the plugin trampoline. */
-			assert(recovery_modid < 0);
-			assert(recovery_stop() < 0);
-			assert(hooks[index].live);
-		}
-		result = ready_original_result;
-		return result;
-	}
-	assert(0);
-	return -1;
+ assert(!mutex_depth && m->impl==&impl && impl.references>0);++releases;
+ if(!--impl.references) {
+  if(stop_redirect_id>=0) (void)recovery_module_stop_redirect(0,NULL);
+  else {++stops;available=0;}
+ }
+ return m;
 }
-
-static int fake_native_stop(SceSize args, const void *argp)
+static void mock_init(void *p)
 {
-	++native_stop_calls;
-	native_stop_args = args;
-	native_stop_argp = argp;
-	record_event(EVENT_NATIVE_STOP);
-	return native_stop_result;
+ assert(p==&plugin && !mutex_depth);++inits;
+ *(uint32_t *)(module_data+RECOVERY_ACTION_FLAGS_OFFSET)=all_capacity_live()?0x80000:0;
+ assert(recovery_stop()<0);
 }
-
-int sceKernelGetModuleInfo(SceUID modid, SceKernelModuleInfo *info)
+static void mock_load(const PafLoadParam *p,LoadFinish finish,int option)
 {
-	assert(modid == reported_recovery_modid);
-	assert(info->size == sizeof(*info));
-	if (module_info_failure)
-		return -1;
-	info->segments[0].vaddr = recovery_text_null ? NULL : recovery_text;
-	info->segments[0].memsz = RECOVERY_TEXT_SIZE + recovery_text_size_delta;
-	info->segments[1].vaddr = recovery_data_null ? NULL : recovery_data;
-	info->segments[1].memsz = RECOVERY_DATA_SIZE + recovery_data_size_delta;
-	return 0;
+ assert(!mutex_depth && p==&param && option==17 && queued_count<8);++loads;queued[queued_count++]=finish;
 }
-
-static HookRecord *find_hook(uint32_t offset, int live)
+static void mock_finish(void *p)
 {
-	unsigned int index;
-
-	for (index = 0; index < hook_count; ++index) {
-		if (hooks[index].offset == offset && hooks[index].live == live)
-			return &hooks[index];
-	}
-	return NULL;
+ assert(!mutex_depth);++finishes;assert(recovery_stop()<0);
+ if(p && owner_unloads) {assert(owner.impl);mock_release(&owner);owner.impl=NULL;plugin.module=NULL;}
+ if(finish_reenters) {finish_reenters=0;recovery_load_hook(&param,mock_finish,17);}
 }
-
-static int live_injection_count(void)
+static void *mock_interface(PafModule *m,int version)
+{assert(m->impl==&impl && version==1 && !mutex_depth);return module_data;}
+static void set_native_mocks(void)
+{module_acquire=mock_acquire;module_release=mock_release;module_get_interface=mock_interface;original_load=mock_load;original_finish=mock_finish;framework_slot=&fake_framework_ptr;}
+static void seed_shell(void)
 {
-	unsigned int index;
-	int count = 0;
-
-	for (index = 0; index < injection_count; ++index)
-		count += injections[index].live != 0;
-	return count;
+ uint8_t *p=shell_text+SHELL_RECOVERY_LOAD_CALL_OFFSET-12;uintptr_t cb=(uintptr_t)shell_text+SHELL_RECOVERY_READY_OFFSET+1;
+ encode_mov(p,0xF240,1,(uint16_t)cb);p[4]=8;p[5]=0xA8;encode_mov(p+6,0xF2C0,1,(uint16_t)(cb>>16));p[10]=0;p[11]=0x22;memcpy(p+12,fixture_profile->load_call,4);
 }
-
-static void initialize_recovery_image(void)
+static void seed_module(void)
 {
-	unsigned int index;
-
-	memset(recovery_text, 0, RECOVERY_TEXT_SIZE);
-	memcpy(recovery_text + RECOVERY_STOP_OFFSET, expected_stop_entry,
-		sizeof(expected_stop_entry));
-	for (index = 0; index < ARRAY_COUNT(recovery_patches); ++index) {
-		const RecoveryPatch *patch = &recovery_patches[index];
-
-		memcpy(recovery_text + patch->offset, patch->expected, patch->size);
-	}
-	memcpy(recovery_original, recovery_text, RECOVERY_TEXT_SIZE);
+ memset(module_text,0,RECOVERY_TEXT_SIZE);memcpy(module_text+RECOVERY_STOP_OFFSET,expected_stop_entry,sizeof(expected_stop_entry));
+ for(unsigned int i=0;i<ARRAY_COUNT(recovery_patches);++i)memcpy(module_text+recovery_patches[i].offset,recovery_patches[i].expected,recovery_patches[i].size);
+ memset(module_data,0,RECOVERY_DATA_SIZE);uint32_t offsets[]={0x99,0x9B,0x15F,0x167,0x207};
+ for(unsigned int i=0;i<5;++i) {uint32_t x=(uint32_t)((uintptr_t)module_text+offsets[i]);memcpy(module_data+i*4,&x,4);}
 }
-
-static void reset_source_state(void)
+static void fresh(const RecoveryProfile *p)
 {
-	active_profile = NULL;
-	ready_hook_id = -1;
-	ready_hook_ref = 0;
-	stop_redirect_id = -1;
-	recovery_modid = -1;
-	native_stop = NULL;
-	recovery_install_complete = 0;
-	clear_patch_ids();
-	lifecycle_busy = 0;
-	initialized = 0;
-	ready_in_flight = 0;
-}
-
-static void reset_case(const RecoveryProfile *profile)
-{
-	free(shell_text);
-	free(recovery_text);
-	free(recovery_original);
-	free(recovery_data);
-	shell_text = calloc(1, profile->shell_text_size);
-	recovery_text = calloc(1, RECOVERY_TEXT_SIZE);
-	recovery_original = malloc(RECOVERY_TEXT_SIZE);
-	recovery_data = calloc(1, RECOVERY_DATA_SIZE);
-	assert(shell_text && recovery_text && recovery_original && recovery_data);
-	memcpy(shell_text + SHELL_RECOVERY_READY_OFFSET, profile->ready_prefix,
-		sizeof(profile->ready_prefix));
-	initialize_recovery_image();
-	memset(&shell_info, 0, sizeof(shell_info));
-	shell_info.size = sizeof(shell_info);
-	shell_info.segments[0].vaddr = shell_text;
-	shell_info.segments[0].memsz = profile->shell_text_size;
-	memset(events, 0, sizeof(events));
-	event_count = 0;
-	memset(hooks, 0, sizeof(hooks));
-	hook_count = 0;
-	hook_install_calls = 0;
-	hook_install_failure_call = -1;
-	hook_release_failure_uid = -1;
-	hook_release_calls = 0;
-	memset(hook_release_order, 0, sizeof(hook_release_order));
-	import_hook_calls = 0;
-	memset(injections, 0, sizeof(injections));
-	injection_count = 0;
-	injection_attempts = 0;
-	injection_failure_call = -1;
-	injection_release_failure_uid = -1;
-	injection_release_calls = 0;
-	memset(injection_release_order, 0, sizeof(injection_release_order));
-	continue_calls = 0;
-	memset(continue_order, 0, sizeof(continue_order));
-	ready_original_result = 77;
-	unload_during_ready = 0;
-	native_stop_calls = 0;
-	native_stop_result = SCE_KERNEL_STOP_SUCCESS;
-	native_stop_args = 0;
-	native_stop_argp = NULL;
-	recovery_available = 1;
-	module_info_failure = 0;
-	reported_recovery_modid = 71;
-	reported_recovery_nid = profile->recovery_nid;
-	recovery_text_null = 0;
-	recovery_data_null = 0;
-	recovery_text_size_delta = 0;
-	recovery_data_size_delta = 0;
-	reset_source_state();
+ /* Every case models a new process. Fault cases deliberately retain resources
+  * until reboot; this harness reset is not a runtime cleanup API. */
+ fixture_profile=p;active_profile=NULL;initialized=0;load_call_id=stop_redirect_id=init_observer_id=recovery_modid=-1;
+ recovery_install_complete=0;preload.impl=NULL;preload_phase=PRELOAD_IDLE;pending_loads=0;
+ load_in_flight=finish_in_flight=init_in_flight=0;native_stop=NULL;native_init=NULL;action_flags=NULL;clear_patch_ids();
+ mutex_depth=mutex_created=acquires=releases=starts=stops=finishes=loads=inits=queued_count=0;
+ available=ctor_error=info_error=bad_nid=create_error=owner_unloads=finish_reenters=attempts=0;fail_injection=fail_release=-1;
+ memset(injections,0,sizeof(injections));memset(&impl,0,sizeof(impl));memset(&owner,0,sizeof(owner));memset(&plugin,0,sizeof(plugin));memset(fake_framework,0,sizeof(fake_framework));
+ memset(&param,0,sizeof(param));param.name=(PafString){"dbrecovery_plugin",17,17};param.module_file=(PafString){"vs0:vsh/common/dbrecovery_plugin.suprx",37,37};param.module_interface_version=param.module_option=1;
+ param.name.length=(uint32_t)strlen(param.name.data);param.module_file.length=(uint32_t)strlen(param.module_file.data);
+ shell_info=(SceKernelModuleInfo){.size=sizeof(shell_info)};shell_info.segments[0].vaddr=shell_text;shell_info.segments[0].memsz=p->shell_text_size;
+ seed_shell();seed_module();
 #if LIVEAREA_DEBUG_LOGGING
-	test_debug_capture_reset();
+ test_debug_capture_reset();
 #endif
 }
-
-static int call_ready(void)
+static void start(void)
+{ assert(recovery_start(7,fixture_profile->shell_nid,&shell_info)==0);set_native_mocks();assert(recovery_stop()<0); }
+static int prepare(void)
 {
-	HookRecord *hook = find_hook(SHELL_RECOVERY_READY_OFFSET, 1);
-	int (*function)(void *);
-
-	assert(hook != NULL);
-	function = (int (*)(void *))hook->function;
-	return function((void *)0x12345678);
+ preload_phase=PRELOAD_PREPARING;int result=prepare_recovery_module(&param);
+ if(recovery_install_complete) {native_init=mock_init;native_stop=mock_stop;}
+ return result;
 }
-
-static int call_recovery_stop(void)
+static void make_plugin(void)
 {
-	if (native_stop != fake_native_stop) {
-		assert((uintptr_t)native_stop ==
-			(uintptr_t)recovery_text + RECOVERY_STOP_OFFSET + 1U);
-		native_stop = fake_native_stop;
-	}
-	return recovery_module_stop_redirect(0x42U, (const void *)0x1234U);
-}
-
-static void start_case(const RecoveryProfile *profile)
-{
-	assert(recovery_start(42, profile->shell_nid, &shell_info) == 0);
-	assert(import_hook_calls == 0);
-	assert(hook_count == 1 && hook_install_calls == 1);
-	assert(hooks[0].modid == 42);
-	assert(hooks[0].offset == SHELL_RECOVERY_READY_OFFSET);
-	assert(hooks[0].live);
-}
-
-static void expect_clean(void)
-{
-	unsigned int index;
-
-	assert(recovery_modid < 0 && stop_redirect_id < 0);
-	assert(native_stop == NULL);
-	assert(!recovery_install_complete);
-	assert(live_injection_count() == 0);
-	assert(memcmp(recovery_text, recovery_original, RECOVERY_TEXT_SIZE) == 0);
-	for (index = 0; index < ARRAY_COUNT(patch_ids); ++index)
-		assert(patch_ids[index] < 0);
-}
-
-static void finish_case(void)
-{
-	if (stop_redirect_id >= 0) {
-		injection_release_failure_uid = -1;
-		assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	}
-	expect_clean();
-	if (initialized) {
-		hook_release_failure_uid = -1;
-		assert(recovery_stop() == 0);
-	}
-	assert(!initialized);
-	assert(find_hook(SHELL_RECOVERY_READY_OFFSET, 1) == NULL);
-}
-
-static void test_happy_path(void)
-{
-	unsigned int profile_index;
-	unsigned int index;
-
-	for (profile_index = 0; profile_index < ARRAY_COUNT(recovery_profiles);
-		++profile_index) {
-		const RecoveryProfile *profile = &recovery_profiles[profile_index];
-
-		reset_case(profile);
-		start_case(profile);
-		event_count = 0;
-		assert(call_ready() == ready_original_result);
-		assert(hook_count == 1);
-		assert(injection_attempts == ARRAY_COUNT(recovery_patches) + 1);
-		assert(live_injection_count() ==
-			(int)ARRAY_COUNT(recovery_patches) + 1);
-		assert(recovery_install_complete);
-		assert(event_count == ARRAY_COUNT(recovery_patches) + 2);
-		for (index = 0; index <= ARRAY_COUNT(recovery_patches); ++index)
-			assert(events[index] == EVENT_INJECT);
-		assert(events[ARRAY_COUNT(recovery_patches) + 1] == EVENT_CONTINUE);
-		assert(memcmp(recovery_text + RECOVERY_STOP_OFFSET,
-			stop_redirect_prefix, sizeof(stop_redirect_prefix)) == 0);
-		assert(recovery_stop() < 0);
-
-		event_count = 0;
-		assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-		assert(event_count == ARRAY_COUNT(recovery_patches) + 2);
-		for (index = 0; index <= ARRAY_COUNT(recovery_patches); ++index)
-			assert(events[index] == EVENT_INJECT_RELEASE);
-		assert(events[ARRAY_COUNT(recovery_patches) + 1] == EVENT_NATIVE_STOP);
-		assert(native_stop_calls == 1);
-		assert(native_stop_args == 0x42U);
-		assert(native_stop_argp == (const void *)0x1234U);
-		for (index = 0; index <= ARRAY_COUNT(recovery_patches); ++index)
-			assert(injection_release_order[index] ==
-				500 + (SceUID)(ARRAY_COUNT(recovery_patches) - index));
-		expect_clean();
-		assert(recovery_stop() == 0);
-		assert(!initialized && !hooks[0].live);
-	}
-	puts("Recovery process scope: three shell profiles, patching and cleanup passed");
-}
-
-static void test_shell_validation(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[0];
-	unsigned int index;
-
-	reset_case(profile);
-	assert(recovery_start(42, 0xDEADBEEFU, &shell_info) < 0);
-	assert(hook_install_calls == 0 && !initialized);
-
-	reset_case(profile);
-	shell_info.segments[0].vaddr = NULL;
-	assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-
-	reset_case(profile);
-	--shell_info.segments[0].memsz;
-	assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-
-	for (index = 0; index < sizeof(profile->ready_prefix); ++index) {
-		reset_case(profile);
-		shell_text[SHELL_RECOVERY_READY_OFFSET + index] ^= 1;
-		assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-		assert(hook_install_calls == 0 && !initialized);
-	}
-
-	reset_case(profile);
-	hook_install_failure_call = 0;
-	assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-	assert(!initialized && hook_count == 0);
-
-	reset_case(profile);
-	start_case(profile);
-	assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-	finish_case();
-	puts("Recovery shell validation: identity, size, bytes, hook failure and re-entry passed");
-}
-
-static void expect_ready_fallback(const RecoveryProfile *profile)
-{
-	memcpy(recovery_original, recovery_text, RECOVERY_TEXT_SIZE);
-	start_case(profile);
-	assert(call_ready() == ready_original_result);
-	assert(hook_count == 1);
-	assert(injection_attempts == 0 && live_injection_count() == 0);
-	assert(recovery_modid < 0 && stop_redirect_id < 0);
-	assert(!recovery_install_complete);
-	finish_case();
-}
-
-static void test_recovery_validation(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[0];
-	unsigned int patch_index;
-	unsigned int byte_index;
-
-	reset_case(profile);
-	recovery_available = 0;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	reported_recovery_nid ^= 1;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	module_info_failure = 1;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	recovery_text_null = 1;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	recovery_data_null = 1;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	recovery_text_size_delta = -1;
-	expect_ready_fallback(profile);
-
-	reset_case(profile);
-	recovery_data_size_delta = 1;
-	expect_ready_fallback(profile);
-
-	for (byte_index = 0; byte_index < sizeof(expected_stop_entry); ++byte_index) {
-		reset_case(profile);
-		recovery_text[RECOVERY_STOP_OFFSET + byte_index] ^= 1;
-		expect_ready_fallback(profile);
-	}
-	for (patch_index = 0; patch_index < ARRAY_COUNT(recovery_patches);
-		++patch_index) {
-		const RecoveryPatch *patch = &recovery_patches[patch_index];
-
-		for (byte_index = 0; byte_index < patch->size; ++byte_index) {
-			reset_case(profile);
-			recovery_text[patch->offset + byte_index] ^= 1;
-			expect_ready_fallback(profile);
-		}
-	}
-	puts("Recovery module validation: identity, segments, stop entry and patch bytes passed");
-}
-
-static void test_install_failures(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[0];
-	unsigned int failure;
-	unsigned int index;
-
-	reset_case(profile);
-	start_case(profile);
-	injection_failure_call = 0;
-	assert(call_ready() == ready_original_result);
-	assert(injection_attempts == 1 && injection_count == 0);
-	expect_clean();
-	finish_case();
-
-	for (failure = 1; failure <= ARRAY_COUNT(recovery_patches); ++failure) {
-		reset_case(profile);
-		start_case(profile);
-		injection_failure_call = (int)failure;
-		assert(call_ready() == ready_original_result);
-		assert(injection_attempts == failure + 1);
-		assert(injection_release_calls == failure);
-		for (index = 0; index + 1 < failure; ++index)
-			assert(injection_release_order[index] ==
-				500 + (SceUID)(failure - 1 - index));
-		assert(injection_release_order[failure - 1] == 500);
-		expect_clean();
-		finish_case();
-	}
-
-	reset_case(profile);
-	start_case(profile);
-	injection_failure_call = 4;
-	injection_release_failure_uid = 502;
-	assert(call_ready() == RECOVERY_ERROR);
-	assert(continue_calls == 0);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(stop_redirect_id == 500);
-	assert(live_injection_count() == 2);
-	assert(!recovery_install_complete);
-	injection_release_failure_uid = -1;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	finish_case();
-
-	reset_case(profile);
-	start_case(profile);
-	injection_failure_call = 1;
-	injection_release_failure_uid = 500;
-	assert(call_ready() == RECOVERY_ERROR);
-	assert(continue_calls == 0);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(stop_redirect_id == 500 && live_injection_count() == 1);
-	assert(!recovery_install_complete);
-	injection_release_failure_uid = -1;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	finish_case();
-	puts("Recovery install failures: redirect, every patch and rollback retention passed");
-}
-
-static void install_active_recovery(const RecoveryProfile *profile)
-{
-	start_case(profile);
-	assert(call_ready() == ready_original_result);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(live_injection_count() ==
-		(int)ARRAY_COUNT(recovery_patches) + 1);
-	assert(recovery_install_complete);
-}
-
-static void test_stop_failures_and_repeat(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[0];
-	unsigned int attempts;
-
-	reset_case(profile);
-	install_active_recovery(profile);
-	native_stop_result = -123;
-	assert(call_recovery_stop() == -123);
-	assert(native_stop_calls == 1);
-	finish_case();
-
-	reset_case(profile);
-	install_active_recovery(profile);
-	attempts = injection_attempts;
-	assert(call_ready() == ready_original_result);
-	assert(injection_attempts == attempts);
-	injection_release_failure_uid = 504;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_CANCEL);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(stop_redirect_id == 500 && live_injection_count() == 2);
-	assert(native_stop_calls == 0);
-	injection_release_failure_uid = -1;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	assert(native_stop_calls == 1);
-	finish_case();
-
-	reset_case(profile);
-	install_active_recovery(profile);
-	injection_release_failure_uid = 500;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_CANCEL);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(stop_redirect_id == 500 && live_injection_count() == 1);
-	assert(native_stop_calls == 0);
-	injection_release_failure_uid = -1;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	assert(native_stop_calls == 1);
-	expect_clean();
-
-	reported_recovery_modid = 72;
-	injection_attempts = 0;
-	injection_count = 0;
-	memset(injections, 0, sizeof(injections));
-	injection_release_calls = 0;
-	assert(call_ready() == ready_original_result);
-	assert(recovery_modid == 72 && live_injection_count() == 8);
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	finish_case();
-	puts("Recovery stop failures: retry-safe cleanup and repeated module cycles passed");
-}
-
-static void test_busy_paths(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[0];
-
-	reset_case(profile);
-	start_case(profile);
-	lifecycle_busy = 1;
-	assert(call_ready() == RECOVERY_ERROR);
-	assert(continue_calls == 0);
-	assert(recovery_modid < 0 && hook_count == 1);
-	lifecycle_busy = 0;
-	assert(call_ready() == ready_original_result);
-	assert(recovery_modid == reported_recovery_modid);
-	assert(recovery_stop() < 0);
-	assert(recovery_modid == reported_recovery_modid);
-	lifecycle_busy = 1;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_CANCEL);
-	assert(native_stop_calls == 0);
-	lifecycle_busy = 0;
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	finish_case();
-	puts("Recovery serialization: busy callback and plugin-stop protection passed");
-
-	reset_case(profile);
-	start_case(profile);
-	recovery_available = 0;
-	unload_during_ready = 1;
-	assert(call_ready() == ready_original_result);
-	assert(ready_in_flight == 0);
-	assert(recovery_stop() == 0);
-	finish_case();
-	puts("Recovery callback lifetime: plugin unload rejected during native fallback and allowed afterward");
-}
-
-static void load_exact(const char *path, uint8_t *target, size_t size)
-{
-	FILE *file = fopen(path, "rb");
-
-	assert(file != NULL);
-	assert(fread(target, 1, size, file) == size);
-	assert(fgetc(file) == EOF);
-	assert(fclose(file) == 0);
-}
-
-static void test_firmware(uint32_t shell_nid, const char *shell_path,
-	const char *recovery_path)
-{
-	const RecoveryProfile *profile = NULL;
-	uint32_t recovery_nid;
-	unsigned int index;
-
-	for (index = 0; index < ARRAY_COUNT(recovery_profiles); ++index) {
-		if (recovery_profiles[index].shell_nid == shell_nid) {
-			profile = &recovery_profiles[index];
-			break;
-		}
-	}
-	assert(profile != NULL);
-	reset_case(profile);
-	load_exact(shell_path, shell_text, profile->shell_text_size);
-	load_exact(recovery_path, recovery_text, RECOVERY_TEXT_SIZE);
-	memcpy(&recovery_nid, recovery_text + 0x2C294U + 52, sizeof(recovery_nid));
-	assert(recovery_nid == profile->recovery_nid);
-	memcpy(recovery_original, recovery_text, RECOVERY_TEXT_SIZE);
-	start_case(profile);
-	assert(call_ready() == ready_original_result);
-	assert(live_injection_count() ==
-		(int)ARRAY_COUNT(recovery_patches) + 1);
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	finish_case();
-	printf("Host recovery lifecycle with firmware bytes passed: shell 0x%08X, %s\n",
-		(unsigned int)shell_nid, recovery_path);
-}
-
+ mock_acquire(&owner,param.module_file.data,NULL,param.module_option,NULL);plugin.module=&owner;
 #if LIVEAREA_DEBUG_LOGGING
-static void test_diagnostics(void)
-{
-	const RecoveryProfile *profile = &recovery_profiles[1];
-
-	reset_case(profile);
-	start_case(profile);
-	assert(test_debug_capture_contains("[recovery] ready-hook"));
-	assert(call_ready() == ready_original_result);
-	assert(test_debug_capture_contains("[recovery] module-patched"));
-	assert(test_debug_capture_contains("[recovery] ready-callback"));
-	assert(test_debug_capture_contains("[recovery] ready-native-enter"));
-	assert(test_debug_capture_contains("[recovery] ready-native-return result=77"));
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_SUCCESS);
-	assert(test_debug_capture_contains("[recovery] module-stop native-return"));
-	assert(test_debug_capture_contains("[recovery] stop-redirect-release"));
-	finish_case();
-	reset_case(profile);
-	shell_text[SHELL_RECOVERY_READY_OFFSET] ^= 1;
-	assert(recovery_start(42, profile->shell_nid, &shell_info) < 0);
-	assert(test_debug_capture_contains("start-rejected reason=ready-bytes"));
-	assert(test_debug_capture_contains("ready-actual"));
-	assert(test_debug_capture_contains("ready-expected"));
-	assert(test_debug_capture_contains("start-failed baseline-capacity-retained"));
-	assert(!test_debug_capture_contains("ready-native-enter"));
-
-	reset_case(profile);
-	start_case(profile);
-	reported_recovery_nid ^= 1;
-	assert(call_ready() == ready_original_result);
-	assert(test_debug_capture_contains("install-rejected reason=module-identity"));
-	assert(test_debug_capture_contains("run_native=1 patched=0"));
-	assert(!test_debug_capture_contains("module-patched"));
-	finish_case();
-
-	reset_case(profile);
-	start_case(profile);
-	recovery_text[recovery_patches[2].offset] ^= 1;
-	memcpy(recovery_original, recovery_text, RECOVERY_TEXT_SIZE);
-	assert(call_ready() == ready_original_result);
-	assert(test_debug_capture_contains("validation-failed reason=patch index=2"));
-	assert(test_debug_capture_contains("patch-actual"));
-	assert(test_debug_capture_contains("patch-expected"));
-	finish_case();
-
-	reset_case(profile);
-	start_case(profile);
-	injection_failure_call = 4;
-	injection_release_failure_uid = 502;
-	assert(call_ready() < 0);
-	assert(test_debug_capture_contains("install-rollback injection_result=-104 cleanup_result=-200"));
-	assert(test_debug_capture_contains("run_native=0 patched=0"));
-	assert(!test_debug_capture_contains("ready-native-enter"));
-	assert(call_recovery_stop() == SCE_KERNEL_STOP_CANCEL);
-	assert(test_debug_capture_contains("module-stop cancelled reason=cleanup-failed"));
-	finish_case();
-
-	reset_case(profile);
-	start_case(profile);
-	lifecycle_busy = 1;
-	assert(call_ready() < 0);
-	assert(test_debug_capture_contains("ready-blocked reason=busy"));
-	lifecycle_busy = 0;
-	finish_case();
-	puts("Recovery diagnostics: success, unpatched fallback, byte mismatch, rollback failure and busy paths passed");
+ if(init_observer_id>=0)recovery_init_observer(&plugin);else mock_init(&plugin);
+#else
+ mock_init(&plugin);
+#endif
 }
-#endif
-
-int main(int argc, char **argv)
+static void check_success(void)
 {
-	int argument;
-
-	assert(argc % 3 == 1);
-	test_happy_path();
-	test_shell_validation();
-	test_recovery_validation();
-	test_install_failures();
-	test_stop_failures_and_repeat();
-	test_busy_paths();
+ fresh(fixture_profile);start();assert(prepare()==1 && starts==1 && inits==0 && impl.references==1 && all_capacity_live());
+ make_plugin();assert(starts==1 && impl.references==2 && inits==1);
+ recovery_load_finished(&plugin);assert(finishes==1 && impl.references==1 && !preload.impl && preload_phase==PRELOAD_IDLE && recovery_modid==42);
+ mock_release(&owner);assert(stops==1 && recovery_modid<0 && !all_capacity_live() && !mutex_depth);
+ assert(!memcmp(module_text+RECOVERY_STOP_OFFSET,expected_stop_entry,sizeof(expected_stop_entry)));
+ for(unsigned int i=0;i<ARRAY_COUNT(recovery_patches);++i)assert(!memcmp(module_text+recovery_patches[i].offset,recovery_patches[i].expected,recovery_patches[i].size));
+}
+static void check_failures(void)
+{
+ unsigned int install_count=8;
 #if LIVEAREA_DEBUG_LOGGING
-	test_diagnostics();
+ ++install_count;
 #endif
-	for (argument = 1; argument < argc; argument += 3) {
-		test_firmware((uint32_t)strtoul(argv[argument], NULL, 0),
-			argv[argument + 1], argv[argument + 2]);
-	}
-	free(shell_text);
-	free(recovery_text);
-	free(recovery_original);
-	free(recovery_data);
-	return 0;
+ for(unsigned int call=1;call<=install_count;++call) {
+  fresh(fixture_profile);start();fail_injection=(int)call;assert(prepare()==1 && !recovery_install_complete && recovery_modid<0);
+  recovery_load_finished(NULL);assert(stops==1 && !preload.impl && !pending_loads);
+  for(unsigned int i=1;i<32;++i)assert(!injections[i].live);
+ }
+ fresh(fixture_profile);start();fail_injection=3;fail_release=102;
+ assert(prepare()==-1 && preload.impl && preload_phase==PRELOAD_BLOCKED && recovery_modid==42);
+ recovery_load_hook(&param,mock_finish,17);assert(!loads && !releases && !load_in_flight);
+ fresh(fixture_profile);start();assert(prepare()==1);fail_release=102;
+ recovery_load_finished(NULL);assert(preload_phase==PRELOAD_BLOCKED && !preload.impl && recovery_modid==42 && !recovery_install_complete);
+ recovery_load_hook(&param,mock_finish,17);assert(!loads);
+ fresh(fixture_profile);start();ctor_error=-7;assert(prepare()==0 && releases==1 && stops==1 && !preload.impl && !recovery_install_complete);
+ fresh(fixture_profile);start();available=1;assert(prepare()==0 && !acquires && !all_capacity_live());
+ fresh(fixture_profile);start();bad_nid=1;assert(prepare()==1 && !all_capacity_live());recovery_load_finished(NULL);assert(stops==1);
+ fresh(fixture_profile);start();info_error=1;assert(prepare()==1 && !all_capacity_live());recovery_load_finished(NULL);assert(stops==1);
+ fresh(fixture_profile);start();module_text[recovery_patches[3].offset]^=1;assert(prepare()==1 && !all_capacity_live());recovery_load_finished(NULL);
+}
+static void check_all_original_bytes(void)
+{
+ for(unsigned int patch=0;patch<ARRAY_COUNT(recovery_patches);++patch)
+  for(unsigned int byte=0;byte<recovery_patches[patch].size;++byte) {
+   fresh(fixture_profile);start();module_text[recovery_patches[patch].offset+byte]^=1;
+   assert(prepare()==1 && !recovery_install_complete && attempts==1);recovery_load_finished(NULL);
+  }
+ for(unsigned int byte=0;byte<sizeof(expected_stop_entry);++byte) {
+  fresh(fixture_profile);start();module_text[RECOVERY_STOP_OFFSET+byte]^=1;
+  assert(prepare()==1 && !recovery_install_complete && attempts==1);recovery_load_finished(NULL);
+ }
+ for(unsigned int byte=0;byte<20;++byte) {
+  fresh(fixture_profile);start();module_data[byte]^=1;
+  assert(prepare()==1 && !recovery_install_complete && attempts==1);recovery_load_finished(NULL);
+ }
+}
+
+static void check_callbacks(void)
+{
+ fresh(fixture_profile);start();assert(prepare()==1);make_plugin();owner_unloads=1;
+ recovery_load_finished(&plugin);assert(!preload.impl && !impl.references && stops==1 && !pending_loads);
+ fresh(fixture_profile);start();assert(prepare()==1);make_plugin();finish_reenters=1;
+ recovery_load_finished(&plugin);assert(pending_loads==1 && preload.impl && queued_count==1);
+ queued[0](&plugin);assert(!preload.impl && impl.references==1 && !pending_loads && finishes==2);
+ mock_release(&owner);assert(stops==1);
+ fresh(fixture_profile);start();assert(prepare()==1);PafModule wrong={0};plugin.module=&wrong;
+ recovery_load_finished(&plugin);assert(preload_phase==PRELOAD_BLOCKED && preload.impl && releases==0);
+ fresh(fixture_profile);start();preload_phase=PRELOAD_PREPARING;recovery_load_hook(&param,mock_finish,17);assert(!loads);
+ fresh(fixture_profile);start();param.module_option=0;recovery_load_hook(&param,mock_finish,17);assert(loads==1 && !acquires && queued[0]==mock_finish);
+ fresh(fixture_profile);start();assert(prepare()==1);init_in_flight=1;assert(recovery_module_stop_redirect(0,NULL)==SCE_KERNEL_STOP_CANCEL && recovery_modid==42);init_in_flight=0;
+}
+static void check_startup(void)
+{
+ fresh(fixture_profile);create_error=1;assert(recovery_start(7,fixture_profile->shell_nid,&shell_info)<0 && !initialized);
+ fresh(fixture_profile);fail_injection=0;assert(recovery_start(7,fixture_profile->shell_nid,&shell_info)<0 && !initialized && !mutex_created);
+ for(unsigned int i=0;i<16;++i) {fresh(fixture_profile);shell_text[SHELL_RECOVERY_LOAD_CALL_OFFSET-12+i]^=1;assert(recovery_start(7,fixture_profile->shell_nid,&shell_info)<0 && !attempts);}
+ fresh(fixture_profile);assert(recovery_start(7,0,&shell_info)<0);
+ fresh(fixture_profile);--shell_info.segments[0].memsz;assert(recovery_start(7,fixture_profile->shell_nid,&shell_info)<0);
+ fresh(fixture_profile);start();fake_framework[21]=5;assert(prepare()==1 && impl.option==3);recovery_load_finished(NULL);
+}
+int main(int argc,char **argv)
+{
+ shell_text=calloc(1,0x550000);module_text=calloc(1,RECOVERY_TEXT_SIZE);module_data=calloc(1,RECOVERY_DATA_SIZE);paf_text=calloc(1,0x300D00);paf_data=calloc(1,0x166D0);
+ assert(shell_text && module_text && module_data && paf_text && paf_data);
+ for(unsigned int i=0;i<ARRAY_COUNT(recovery_profiles);++i) {
+  fixture_profile=&recovery_profiles[i];check_success();check_failures();check_all_original_bytes();check_callbacks();check_startup();
+  printf("Recovery preload lifecycle/rollback/ownership/callbacks passed: 0x%08X logging=%d\n",fixture_profile->shell_nid,LIVEAREA_DEBUG_LOGGING);
+ }
+ assert((argc-1)%3==0);
+ for(int i=1;i<argc;i+=3) {
+  uint32_t nid=(uint32_t)strtoul(argv[i],NULL,0);const RecoveryProfile *p=NULL;
+  for(unsigned int j=0;j<ARRAY_COUNT(recovery_profiles);++j)if(recovery_profiles[j].shell_nid==nid)p=&recovery_profiles[j];
+  assert(p);fresh(p);FILE *f=fopen(argv[i+1],"rb");assert(f && fread(shell_text,1,p->shell_text_size,f)==p->shell_text_size);fclose(f);
+  /* Validate invariant call-site instructions from the actual shell; adjust
+   * only its loader-relocated local callback immediates to the host fixture. */
+  uint8_t *ctx=shell_text+SHELL_RECOVERY_LOAD_CALL_OFFSET-12;
+  assert(ctx[4]==8 && ctx[5]==0xA8 && ctx[10]==0 && ctx[11]==0x22 && !memcmp(ctx+12,p->load_call,4));seed_shell();
+  f=fopen(argv[i+2],"rb");assert(f && fread(module_text,1,RECOVERY_TEXT_SIZE,f)==RECOVERY_TEXT_SIZE);fclose(f);
+  start();assert(prepare()==1 && recovery_install_complete);make_plugin();recovery_load_finished(&plugin);mock_release(&owner);
+  printf("Real recovery/shell bytes passed: 0x%08X\n",nid);
+ }
+ free(shell_text);free(module_text);free(module_data);free(paf_text);free(paf_data);return 0;
 }

--- a/tests/test_recovery_hook_scope.py
+++ b/tests/test_recovery_hook_scope.py
@@ -1,24 +1,11 @@
 from pathlib import Path
-
-source = (Path(__file__).resolve().parents[1] / "src" / "recovery.c").read_text()
-
-for required in (
-    "SHELL_RECOVERY_READY_OFFSET 0x1BFEU",
-    "RECOVERY_STOP_OFFSET 0x1EU",
-    "taiHookFunctionOffset(&ready_hook_ref, shell_modid",
-    "taiInjectData(module.modid, 0, RECOVERY_STOP_OFFSET",
-    "stop_redirect_prefix",
-    "recovery_module_stop_redirect",
-    'taiGetModuleInfo("SceDbRecovery"',
-):
-    assert required in source, required
-
-for forbidden in (
-    "taiHookFunctionImport(",
-    '"SceLibKernel"',
-    '"ScePaf"',
-    "0x72CD301FU",
-    "0x086867A8U",
-    "0x8E4A7716U",
-):
-    assert forbidden not in source, forbidden
+source=(Path(__file__).resolve().parents[1]/'src/recovery.c').read_text()
+for required in ('SHELL_RECOVERY_LOAD_CALL_OFFSET 0xC1EU', 'shell_detour_encode_call(',
+                 'taiInjectData(shell_modid,0,SHELL_RECOVERY_LOAD_CALL_OFFSET',
+                 'module_acquire(&preload', 'prepare_recovery_module',
+                 'taiInjectData(module.modid, 0, RECOVERY_STOP_OFFSET',
+                 'original_finish(plugin)', 'module_release(&preload)'):
+    assert required in source,required
+for forbidden in ('taiHookFunctionImport(', 'taiHookFunctionOffset(', 'TAI_CONTINUE(',
+                  'recovery_ready_hook', '"SceLibKernel"'):
+    assert forbidden not in source,forbidden

--- a/tests/test_recovery_preload_arm.py
+++ b/tests/test_recovery_preload_arm.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Compiled recovery preload, native PAF Module lifetime and recovery decision.
+
+OS, strings/maps, scheduling and rendering services are modeled. Native recovery
+initialization executes in a separate Unicorn context with the exact patch bytes
+installed by the compiled plugin. No Vita or real database writes occur.
+Usage: test_recovery_preload_arm.py PLUGIN_ELF EVIDENCE_ROOT [--database DB ...]
+"""
+from pathlib import Path
+import argparse,json,sqlite3,struct
+from unicorn import UC_HOOK_CODE
+from unicorn import arm_const as R
+from arm_helpers import elf,machine,word,check_encoder,STACK,RETURN,HEAP
+import test_recovery_firmware as rec
+
+REC, RECDATA, SHELL, SHELLDATA = 0x81400000,0x8143F000,0x81800000,0x82100000
+PARAM, NAME, FILENAME, PLUGIN, OWNER, INFO = [HEAP+x for x in (0x100,0x200,0x240,0x500,0x700,0x800)]
+
+class Trial:
+    def __init__(self,plugin,root,profile,counts):
+        self.u=machine(plugin);self.sym=plugin[2];self.root=root;self.profile=profile;self.counts=counts
+        self.paf,self.pdata=(0x83200E90,0x811607E0) if profile==2 else (0x81000000,0x81301000)
+        files=['retail360-paf.text.bin','retail365-paf.text.bin','ptel360-paf.text.bin']
+        self.paftext=(root/'worktrees/missing-apps-recovery/build/cache-parity-evidence'/files[profile]).read_bytes()
+        if profile==2:self.u.mem_map(self.paf&~4095,0x302000);self.u.mem_write(self.paf,self.paftext)
+        else:self.u.mem_map(self.paf+0x40000,0x2C1000);self.u.mem_write(self.paf+0x40000,self.paftext[0x40000:])
+        self.u.mem_map(self.pdata&~4095,0x18000)
+        self.rectext=(root/f'worktrees/missing-apps-recovery/build/recovery-evidence/retail{365 if profile==1 else 360}-recovery.text.bin').read_bytes()
+        self.u.mem_map(REC,0x43000);self.u.mem_write(REC,self.rectext)
+        self.offsets=[0x99,0x9B,0x15F,0x167,0x207]
+        runtime=(root/f'worktrees/missing-apps-recovery/build/recovery-evidence/retail{365 if profile==1 else 360}-recovery.analysis.elf').read_bytes()
+        eh=struct.unpack_from('<16sHHIIIIIHHHHHH',runtime);segments=[struct.unpack_from('<8I',runtime,eh[5]+i*eh[9]) for i in range(eh[10])];data_segment=[x for x in segments if x[0]==1][1]
+        for offset in range(0x18,0x38,4):
+            value=struct.unpack_from('<I',runtime,data_segment[1]+offset)[0]
+            if rec.BASE<=value<rec.BASE+len(self.rectext):value+=REC-rec.BASE
+            word(self.u,RECDATA+offset,value)
+        for i,x in enumerate(self.offsets):word(self.u,RECDATA+4*i,REC+x)
+        shells=[root/'firmware-evidence/3.60/SceShell.text.bin',root/'firmware-evidence/3.65/SceShell.text.bin',root/'release-v1.9.0-evidence/ptel360-shell.text.bin']
+        self.shell=shells[profile].read_bytes();self.u.mem_map(SHELL,(len(self.shell)+4095)&~4095);self.u.mem_write(SHELL,self.shell)
+        self.u.mem_map(SHELLDATA,0x10000)
+        self.nid=[0x0552F692,0x5549BF1F,0xEAB89D5C][profile]
+        self.rnid=0x3F76E38F if profile==1 else 0xC1F30F67
+        self.pnid=0x73F90499 if profile==1 else 0xCD679177
+        self.import_load=[0x45CA50,0x45CE98,0x452C08][profile]
+        self.heap=HEAP+0x2000;self.live={};self.cache={};self.mutex={};self.available=False;self.start_calls=0;self.stop_calls=0
+        self.callbacks=[];self.logs=[];self.patches={};self.injections=0;self.fail_at=-1;self.fail_release=-1;self.kernel_failure=0
+        self.native_inits=0;self.finished=0;self.init_cpu=None;self.expected_flags=0x80000;self.omit_interface=False
+        self.cachehead=self.alloc(32);word(self.u,self.pdata+0xDEE0,self.cachehead)
+        framework=self.alloc(128);word(self.u,self.pdata+0x194,framework)
+        self.u.mem_write(NAME,b'dbrecovery_plugin\0');self.u.mem_write(FILENAME,b'vs0:vsh/common/dbrecovery_plugin.suprx\0')
+        self.u.mem_write(PARAM,bytes(160));word(self.u,PARAM,NAME);word(self.u,PARAM+4,17)
+        word(self.u,PARAM+104,FILENAME);word(self.u,PARAM+108,len(b'vs0:vsh/common/dbrecovery_plugin.suprx'))
+        word(self.u,PARAM+116,1);word(self.u,PARAM+120,1)
+        word(self.u,INFO,0x1B8);word(self.u,INFO+0x15C,SHELL);word(self.u,INFO+0x160,len(self.shell))
+        self.mov(SHELL+0xC12,0xF240,1,(SHELL+0x1BFF)&65535);self.mov(SHELL+0xC18,0xF2C0,1,(SHELL+0x1BFF)>>16)
+        # The original finish callback is exercised separately below; this
+        # harness service stands in for its externally visible completion.
+        self.relocate_ready()
+        self.u.hook_add(UC_HOOK_CODE,self.step)
+        self.names={addr&~1:name for name,addr in self.sym.items()}
+        self.active_stop_return=[]
+
+    def rd(self,a):return struct.unpack('<I',self.u.mem_read(a,4))[0]
+    def string(self,a):return bytes(self.u.mem_read(a,256)).split(b'\0',1)[0].decode()
+    def alloc(self,size):
+        a=self.heap;self.heap=(a+max(size,1)+15)&~15;assert self.heap<HEAP+0xE000
+        self.u.mem_write(a,bytes(max(size,1)));self.live[a]=size;return a
+    def free(self,a):
+        if not a:return
+        assert a in self.live,hex(a);del self.live[a]
+    def mov(self,a,op,reg,value):
+        x=op|(value>>12)|((value>>1)&0x400);y=((value<<4)&0x7000)|(reg<<8)|(value&255)
+        self.u.mem_write(a,struct.pack('<HH',x,y))
+    def ret(self,v=0):
+        self.u.reg_write(R.UC_ARM_REG_R0,v&0xFFFFFFFF);self.u.reg_write(R.UC_ARM_REG_PC,self.u.reg_read(R.UC_ARM_REG_LR))
+    def call(self,where,*args,end=RETURN):
+        u=self.u;where=self.sym[where] if isinstance(where,str) else where
+        u.reg_write(R.UC_ARM_REG_SP,STACK+0xF000);u.reg_write(R.UC_ARM_REG_LR,RETURN|1)
+        for i,v in enumerate(args):
+            if i<4:u.reg_write(getattr(R,f'UC_ARM_REG_R{i}'),v)
+            else:word(u,STACK+0xF000+4*(i-4),v)
+        for i in range(4,12):u.reg_write(getattr(R,f'UC_ARM_REG_R{i}'),0x12340000+i)
+        try:u.emu_start(where|1,end,count=250000)
+        except Exception:
+            print('ARM failure',hex(u.reg_read(R.UC_ARM_REG_PC)),self.logs[-5:]);raise
+        assert u.reg_read(R.UC_ARM_REG_PC)==end,hex(u.reg_read(R.UC_ARM_REG_PC))
+        assert u.reg_read(R.UC_ARM_REG_SP)==STACK+0xF000
+        for i in range(4,12):assert u.reg_read(getattr(R,f'UC_ARM_REG_R{i}'))==0x12340000+i
+        assert not any(self.mutex.values()),self.mutex
+        return u.reg_read(R.UC_ARM_REG_R0)
+
+    def branch_target(self,offset):
+        a,b=struct.unpack_from('<HH',self.shell,offset);sign=(a>>10)&1
+        imm=(sign<<24)|((1^((b>>13)&1)^sign)<<23)|((1^((b>>11)&1)^sign)<<22)|((a&1023)<<12)|((b&2047)<<1)
+        if sign:imm-=1<<25
+        pc=offset+4
+        if not (b&0x1000):pc&=~3
+        return SHELL+pc+imm
+
+    def relocate_ready(self):
+        # Apply only the firmware loader's local MOVW/MOVT address rebasing in
+        # this small callback; branch immediates stay invariant under rebasing.
+        old_base=0x83200DC0 if self.profile==2 else 0x81000000
+        old_data=[0x81542000,0x81543000,0x83780FB0][self.profile]
+        low={}
+        for off in range(0x1BFE,0x1C48,2):
+            a,b=struct.unpack_from('<HH',self.shell,off);op=a&0xFBF0
+            if op not in (0xF240,0xF2C0) or b&0x8000:continue
+            register=(b>>8)&15;value=((a&15)<<12)|((a&0x400)<<1)|((b&0x7000)>>4)|(b&255)
+            if op==0xF240:low[register]=(off,value)
+            elif register in low:
+                start,small=low.pop(register);full=(value<<16)|small;dest=None
+                if old_base<=full<old_base+len(self.shell):dest=SHELL+full-old_base
+                elif old_data<=full<old_data+0xA0000:dest=SHELLDATA+full-old_data
+                if dest is not None:self.mov(SHELL+start,0xF240,register,dest&65535);self.mov(SHELL+off,0xF2C0,register,dest>>16)
+        self.get_plugin_interface=self.branch_target(0x1C02)
+        self.ready_environment_check=self.branch_target(0x1C16)
+
+    def module_interface(self,wrapper):
+        impl=self.rd(wrapper);head=self.rd(impl+16);node=self.alloc(24)
+        for off,v in [(0,head),(4,head),(8,head),(12,1),(16,RECDATA)]:word(self.u,node+off,v)
+        for off in (0,4,8):word(self.u,head+off,node)
+        word(self.u,impl+20,1)
+
+    def native_initialize(self):
+        cpu=rec.emulator(self.rectext)
+        for off,_,_ in rec.PATCHES:cpu.mem_write(rec.BASE+off,bytes(self.u.mem_read(REC+off,4 if off not in (0x6084,) else 2)))
+        visible,hidden=self.counts
+        def hook(c,pc,size,_):
+            rel=pc-rec.BASE;value=None
+            if rel==0x4BF4:word(c,c.reg_read(R.UC_ARM_REG_R0),0);value=0
+            elif rel in (0xC994,0xCCB6,0xCB36,0x2AF44,0x2AD54,0x2AE64,0x4DE,0x2BCE4,0x2B524):value=0
+            elif rel==0x2AF24:value=hidden
+            elif rel==0x2AD44:value=visible
+            elif rel==0x2BC74:c.mem_write(c.reg_read(R.UC_ARM_REG_R0),bytes(16));value=0
+            elif rel==0x2BC24:value=1
+            elif rel==0x2B184:raise AssertionError('Native recovery stack guard')
+            if value is not None:c.reg_write(R.UC_ARM_REG_R0,value);c.reg_write(R.UC_ARM_REG_PC,c.reg_read(R.UC_ARM_REG_LR))
+        cpu.hook_add(UC_HOOK_CODE,hook);cpu.reg_write(R.UC_ARM_REG_R0,rec.STACK+0x100)
+        cpu.emu_start(rec.BASE+0x9B,rec.RETURN,count=10000);assert cpu.reg_read(R.UC_ARM_REG_PC)==rec.RETURN
+        flags=struct.unpack('<I',cpu.mem_read(rec.BASE+0x40100,4))[0]
+        word(self.u,RECDATA+0x1100,flags);self.init_cpu=cpu;self.native_inits+=1;return flags
+
+    def step(self,u,pc,size,_):
+        args=[u.reg_read(getattr(R,f'UC_ARM_REG_R{i}')) for i in range(4)];name=self.names.get(pc);rel=pc-self.paf
+        if name in ('debug_log_open','debug_log_close','debug_log_flush'):pass
+        elif name=='debug_logf':self.logs.append(self.string(args[1]))
+        elif name=='sceKernelCreateLwMutex':assert args[2:]==[0,0];self.mutex[args[0]]=0
+        elif name=='sceKernelDeleteLwMutex':assert not self.mutex[args[0]]
+        elif name=='sceKernelLockLwMutex':assert not self.mutex.get(args[0],0);self.mutex[args[0]]=1
+        elif name=='sceKernelUnlockLwMutex':assert self.mutex[args[0]];self.mutex[args[0]]=0
+        elif name=='taiGetModuleInfo':
+            which=self.string(args[0])
+            if which=='ScePaf':uid,nid=90,self.pnid
+            else:
+                assert which=='SceDbRecovery'
+                if not self.available:self.ret(-1);return
+                uid,nid=42,self.rnid
+            word(u,args[1]+4,uid);word(u,args[1]+8,nid)
+        elif name=='sceKernelGetModuleInfo':
+            assert args[0] in (42,90)
+            segments=[(self.paf,0x300D00),(self.pdata,0x166D0)] if args[0]==90 else [(REC,0x3E9E8),(RECDATA,0x3094)]
+            for i,(ptr,length) in enumerate(segments):word(u,args[1]+0x15C+i*24,ptr);word(u,args[1]+0x160+i*24,length)
+        elif name=='taiInjectDataForUser':
+            a=[self.rd(args[0]+4*i) for i in range(7)];_,uid,segment,offset,_,source,length=a
+            number=self.injections;self.injections+=1
+            if number==self.fail_at:self.ret(-1);return
+            assert uid in (7,42) and (uid!=7 or (segment==0 and offset==0xC1E))
+            at=(SHELL if uid==7 else RECDATA if segment else REC)+offset
+            self.patches[100+number]=(at,bytes(u.mem_read(at,length)));u.mem_write(at,bytes(u.mem_read(source,length)));self.ret(100+number);return
+        elif name=='taiInjectRelease':
+            if args[0]==self.fail_release:self.ret(-1);return
+            at,previous=self.patches.pop(args[0]);u.mem_write(at,previous)
+        elif name in ('sceClibMemcpy','memcpy'):
+            u.mem_write(args[0],bytes(u.mem_read(args[1],args[2])));self.ret(args[0]);return
+        elif name in ('sceClibMemset','memset'):
+            u.mem_write(args[0],bytes([args[1]&255])*args[2]);self.ret(args[0]);return
+        elif rel in (0x53D50,0x53D64):
+            if rel==0x53D50:assert not self.mutex.get(args[0],0);self.mutex[args[0]]=1
+            else:assert self.mutex[args[0]];self.mutex[args[0]]=0
+        elif rel==0x536FC:self.ret(self.alloc(args[0]));return
+        elif rel==0x53778:self.free(args[0])
+        elif rel==0x51BC8:self.ret(len(self.string(args[0])));return
+        elif rel in (0x1DC174,0x1DC1EC):
+            data=bytes(u.mem_read(args[1],args[2])) if rel==0x1DC174 else self.string(self.rd(args[1])).encode()
+            buf=self.alloc(len(data)+1);u.mem_write(buf,data+b'\0');word(u,args[0],buf);word(u,args[0]+4,len(data));word(u,args[0]+8,len(data));self.ret(args[0]);return
+        elif rel==0x1E4538:word(u,args[0],self.cache.get(self.string(self.rd(args[2])),self.cachehead))
+        elif rel==0x1E43FC:
+            key=self.string(self.rd(args[1]));assert key not in self.cache;node=self.alloc(32);self.cache[key]=node;self.ret(node);return
+        elif rel==0x1E495C:
+            key=self.string(self.rd(args[1]));self.free(self.cache.pop(key))
+        elif rel==0x1E4ABC:
+            head=self.rd(args[0]);node=self.rd(head)
+            if node!=head:self.free(node)
+        elif rel==0x262578:u.reg_write(R.UC_ARM_REG_R1,0)
+        elif rel==0x5076A:
+            u.mem_write(args[0],bytes([args[1]&255])*args[2]);self.ret(args[0]);return
+        elif rel==0x262588:
+            assert self.string(args[0])=='vs0:vsh/common/dbrecovery_plugin.suprx' and args[1]==0
+            assert self.rd(args[2])==4;self.available=True;self.ret(42);return
+        elif rel==0x262478:
+            assert args[0]==42 and args[1]==4 and args[3]==0
+            assert not self.mutex.get(self.sym['lifecycle_mutex'],0)
+            self.start_calls+=1;wrapper=self.rd(args[2]);
+            if not self.omit_interface:self.module_interface(wrapper)
+            word(u,self.rd(u.reg_read(R.UC_ARM_REG_SP)+4),0);self.ret(self.kernel_failure);return
+        elif rel==0x262408:
+            assert args[0]==42 and not any(self.mutex.values())
+            self.stop_calls+=1;self.active_stop_return.append((u.reg_read(R.UC_ARM_REG_LR),self.rd(u.reg_read(R.UC_ARM_REG_SP)+4)))
+            u.reg_write(R.UC_ARM_REG_R0,0);u.reg_write(R.UC_ARM_REG_R1,0);u.reg_write(R.UC_ARM_REG_LR,RETURN+0x401);u.reg_write(R.UC_ARM_REG_PC,REC+0x1F);return
+        elif pc==RETURN+0x400:
+            lr,out=self.active_stop_return.pop();word(u,out,args[0]);u.reg_write(R.UC_ARM_REG_R0,0 if args[0]==0 else 0x80000001);u.reg_write(R.UC_ARM_REG_PC,lr);return
+        elif rel==0x262368:assert args[0]==42;self.available=False
+        elif rel==0x516F0:pass
+        elif pc==REC+0x9A:
+            assert args[0]==PLUGIN;self.native_initialize()
+        elif pc==REC+0x1E:
+            # On first entry an installed literal redirect must execute. Once
+            # restored, model native runtime finalization (the immutable body
+            # is checked by the redirect test and returns SCE_STOP_SUCCESS).
+            if self.u.mem_read(pc,2)==b'\xdf\xf8':return
+            assert bytes(u.mem_read(pc,10))==self.rectext[0x1E:0x28]
+        elif pc==SHELL+self.import_load:
+            assert args[0]==PARAM and args[2]==0;self.callbacks.append(args[1])
+        elif pc==self.get_plugin_interface:
+            self.ret(RECDATA+0x18 if args[0] else 0);return
+        elif pc==self.ready_environment_check:self.ret(1);return
+        elif pc==SHELL+0x1BFE:
+            assert args[0] in (PLUGIN,0);self.finished+=1;return
+        elif pc==REC+0x21C:
+            assert args[0]==SHELL+0x1BE3
+            # Completion callback registration uses the actual native recovery
+            # entry in the separate firmware context; it must not change flags.
+            if self.init_cpu:
+                c=self.init_cpu;c.reg_write(R.UC_ARM_REG_SP,rec.STACK+0xF000);c.reg_write(R.UC_ARM_REG_LR,rec.RETURN|1);c.reg_write(R.UC_ARM_REG_R0,SHELL+0x1BE3)
+                c.emu_start(rec.BASE+0x21D,rec.RETURN,count=1000);assert c.reg_read(R.UC_ARM_REG_PC)==rec.RETURN
+                flags=struct.unpack('<I',c.mem_read(rec.BASE+0x40100,4))[0];assert flags==self.rd(RECDATA+0x1100)
+        else:return
+        self.ret()
+
+    def execute(self):
+        assert self.call('recovery_start',7,self.nid,INFO)==0
+        assert self.call('recovery_stop')==0xFFFFFFFF
+        self.call(SHELL+0xC1E,PARAM,SHELL+0x1BFF,0,end=SHELL+0xC22)
+        assert self.available and self.start_calls==1 and len(self.callbacks)==1
+        held=self.rd(self.sym['preload']);assert self.rd(held+28)==1
+        assert self.call(self.paf+0x4722A,OWNER,FILENAME,0,1,0)==OWNER
+        assert self.rd(OWNER)==held and self.rd(held+28)==2 and self.start_calls==1
+        word(self.u,PLUGIN+48,OWNER)
+        # Execute the actual native Plugin constructor's interface-copy block.
+        u=self.u;u.reg_write(R.UC_ARM_REG_R6,PLUGIN);u.reg_write(R.UC_ARM_REG_R8,PARAM)
+        u.emu_start(self.paf+0x588DB,self.paf+0x58904,count=1000)
+        assert self.rd(PLUGIN+32)==self.rd(RECDATA+4)
+        u.reg_write(R.UC_ARM_REG_SP,STACK+0xF000);u.reg_write(R.UC_ARM_REG_R6,PLUGIN)
+        u.emu_start(self.paf+0x58E5F,self.paf+0x58E6A,count=200000)
+        assert self.native_inits==1 and self.rd(RECDATA+0x1100)==self.expected_flags
+        self.call(self.callbacks.pop(),PLUGIN)
+        assert self.finished==1 and self.rd(held+28)==1 and self.rd(self.sym['preload'])==0
+        self.call(self.paf+0x473D4,OWNER)
+        assert self.stop_calls==1 and not self.available and not self.cache
+        assert len(self.patches)==1 and len(self.live)==2  # Permanent call site; fixture heap only.
+        for off,expected,_ in rec.PATCHES:assert bytes(u.mem_read(REC+off,len(expected)))==expected
+        for i,offset in enumerate(self.offsets):assert self.rd(RECDATA+i*4)==REC+offset
+        assert self.call('recovery_stop')==0xFFFFFFFF
+
+
+def main():
+    p=argparse.ArgumentParser();p.add_argument('plugin',type=Path);p.add_argument('evidence_root',type=Path);p.add_argument('--database',action='append',type=Path,default=[]);a=p.parse_args()
+    cases=[(500,49),(500,73)]
+    for db in a.database:
+        c=sqlite3.connect('file:'+str(db)+'?mode=ro',uri=True)
+        hidden=c.execute('SELECT COUNT(*) FROM tbl_appinfo_icon i JOIN tbl_appinfo_page p USING(pageId) WHERE type=0 AND pageNo=-100000000').fetchone()[0]
+        visible=c.execute('SELECT COUNT(*) FROM tbl_appinfo_icon i JOIN tbl_appinfo_page p USING(pageId) WHERE type=0 AND pageNo<>-100000000').fetchone()[0]
+        if (visible,hidden) not in cases:cases.append((visible,hidden))
+    binary=elf(a.plugin)
+    print("Thumb BL call encoder:",check_encoder(binary,link=True),"boundary/invalid cases passed")
+    for firmware in range(3):
+        for counts in cases:
+            h=Trial(binary,a.evidence_root,firmware,counts);h.execute();print('PASS profile',firmware,'counts',counts,'native Module cache reuse, pre-init flag, completion, rollback')
+    fault_cases=0
+    for firmware in range(3):
+        for point in ((1,4,9) if 'recovery_init_observer' in binary[2] else (1,4)):
+            h=Trial(binary,a.evidence_root,firmware,(500,49));h.fail_at=point;h.expected_flags=0;h.execute();fault_cases+=1
+        for failure in ('start','interface','partial','load-failed','stop-cleanup'):
+            h=Trial(binary,a.evidence_root,firmware,(500,49))
+            if failure=='start':h.kernel_failure=-1
+            if failure=='interface':h.omit_interface=True
+            if failure=='partial':h.fail_at=4;h.fail_release=102
+            assert h.call('recovery_start',7,h.nid,INFO)==0
+            h.call(SHELL+0xC1E,PARAM,SHELL+0x1BFF,0,end=SHELL+0xC22)
+            if failure in ('start','interface'):
+                assert h.rd(h.sym['preload'])==0 and not h.cache and h.callbacks==[SHELL+0x1BFF]
+            elif failure=='partial':
+                assert not h.callbacks and h.rd(h.sym['preload']) and not h.native_inits
+            elif failure=='stop-cleanup':
+                h.fail_release=102;h.call(h.callbacks.pop(),0)
+                assert h.available and not h.cache and h.rd(h.sym['preload'])==0 and h.rd(h.sym['preload_phase'])==4
+                h.call(SHELL+0xC1E,PARAM,SHELL+0x1BFF,0,end=SHELL+0xC22);assert not h.callbacks
+            else:
+                h.call(h.callbacks.pop(),0)
+                assert not h.available and not h.cache and h.rd(h.sym['preload'])==0 and len(h.live)==2
+            fault_cases+=1
+    print('Compiled ARM recovery preload:',len(cases)*3+fault_cases,'scenarios passed. Native PAF Module code, recovery initializer/decision and original SceShell ready callback run; OS, maps/strings, scheduling and UI are modeled.')
+if __name__=='__main__':main()


### PR DESCRIPTION
With 500 visible apps, v1.8.0/v1.9.0 install recovery patches after the native initializer has already decided the stock limit leaves no space. Preload the recovery module at SceShell's specific load call, apply the limits before Plugin initialization, then resume native asynchronous loading.

The implementation reuses PAF's module cache and balances its extra reference after completion. It removes the late ready-entry hook, calls the original void callback directly, protects failed cleanup from later loads, and adds optional diagnostic initializer/lifecycle events. Shared PAF/SceLibKernel code is untouched. Capacity and the SceShell-owned cache policy are unchanged.

Reporter validation: [#10 on retail 3.65](https://github.com/devnoname120/livearea_nolimits/issues/10#issuecomment-5642660836) restored 73 hidden apps, retained all 573 bubbles across 15 pages after another reboot, and supplied cache-enabled candidate logs confirming early patching and complete cleanup. [#8 on retail 3.60](https://github.com/devnoname120/livearea_nolimits/issues/8#issuecomment-5642650846) reports recovered icons, repeated successful reboots and game/homebrew launches after the no-cache candidate request; logs and the cache-enabled comparison are pending.

Validation: host ASan/UBSan lifecycle, rollback and firmware-byte checks; compiled ARM recovery preload across retail 3.60/3.65 and PTEL 3.60; both reporter count cases; native recovery capacity/stop checks and cache ARM regression. The v2.0.0 logless build reproduces exactly across two independent build directories and passes 27 recovery scenarios plus the 30-scenario cache regression. Matching diagnostic variants pass 30 recovery scenarios each. OS, strings/maps, scheduling and UI services are modeled in the ARM tests; reporter hardware testing used diagnostic candidates.

Refs #8, #10.
